### PR TITLE
$output issue in verifyApplicationDoesntExist

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -34,7 +34,7 @@ class NewCommand extends \Symfony\Component\Console\Command\Command {
 				$directory = getcwd().'/'.$input->getArgument('name')
 			);
 		} catch (\Exception $ex) {
-			$this->output->writeln($ex->getMessage());
+			$output->writeln($ex->getMessage());
 			exit(1);
 		}
 


### PR DESCRIPTION
When trying to install the application into an existing folder, the installer throws a bunch of errors that indicates that the `$output` variable does not exists in the "verifyApplcationDoesntExist" method.

This patch fixes this issue, and directs the message to the `execute()` method so that the message can be written. 
