### PR TITLE
Fix exception in verifyApplicationDoesntExist.

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -30,7 +30,8 @@ class NewCommand extends \Symfony\Component\Console\Command\Command {
 	protected function execute(InputInterface $input, OutputInterface $output)
 	{
 		$this->verifyApplicationDoesntExist(
-			$directory = getcwd().'/'.$input->getArgument('name')
+			$directory = getcwd().'/'.$input->getArgument('name'),
+			$output
 		);
 
 		$output->writeln('<info>Crafting application...</info>');
@@ -48,7 +49,7 @@ class NewCommand extends \Symfony\Component\Console\Command\Command {
 	 * @param  string  $directory
 	 * @return void
 	 */
-	protected function verifyApplicationDoesntExist($directory)
+	protected function verifyApplicationDoesntExist($directory, OutputInterface $output)
 	{
 		if (is_dir($directory))
 		{


### PR DESCRIPTION
Previously the OutputInterface was not being passed to this method which resulted in it throwing an "Undefined variable" exception.

Steps to reproduce:

```
mkdir install-laravel-here
laravel new install-laravel-here
```

And observe:

```
PHP Notice:  Undefined variable: output in /Users/mfarmer/.composer/vendor/laravel/installer/src/NewCommand.php on line 55
PHP Stack trace:
PHP   1. {main}() /Users/mfarmer/.composer/vendor/laravel/installer/laravel:0
PHP   2. Symfony\Component\Console\Application->run() /Users/mfarmer/.composer/vendor/laravel/installer/laravel:10
PHP   3. Symfony\Component\Console\Application->doRun() /Users/mfarmer/.composer/vendor/symfony/console/Symfony/Component/Console/Application.php:124
PHP   4. Symfony\Component\Console\Application->doRunCommand() /Users/mfarmer/.composer/vendor/symfony/console/Symfony/Component/Console/Application.php:193
PHP   5. Symfony\Component\Console\Command\Command->run() /Users/mfarmer/.composer/vendor/symfony/console/Symfony/Component/Console/Application.php:889
PHP   6. Laravel\Installer\Console\NewCommand->execute() /Users/mfarmer/.composer/vendor/symfony/console/Symfony/Component/Console/Command/Command.php:252
PHP   7. Laravel\Installer\Console\NewCommand->verifyApplicationDoesntExist() /Users/mfarmer/.composer/vendor/laravel/installer/src/NewCommand.php:34
PHP Fatal error:  Call to a member function writeln() on a non-object in /Users/mfarmer/.composer/vendor/laravel/installer/src/NewCommand.php on line 55
PHP Stack trace:
PHP   1. {main}() /Users/mfarmer/.composer/vendor/laravel/installer/laravel:0
PHP   2. Symfony\Component\Console\Application->run() /Users/mfarmer/.composer/vendor/laravel/installer/laravel:10
PHP   3. Symfony\Component\Console\Application->doRun() /Users/mfarmer/.composer/vendor/symfony/console/Symfony/Component/Console/Application.php:124
PHP   4. Symfony\Component\Console\Application->doRunCommand() /Users/mfarmer/.composer/vendor/symfony/console/Symfony/Component/Console/Application.php:193
  2 {
PHP   5. Symfony\Component\Console\Command\Command->run() /Users/mfarmer/.composer/vendor/symfony/console/Symfony/Component/Console/Application.php:889
PHP   6. Laravel\Installer\Console\NewCommand->execute() /Users/mfarmer/.composer/vendor/symfony/console/Symfony/Component/Console/Command/Command.php:252
PHP   7. Laravel\Installer\Console\NewCommand->verifyApplicationDoesntExist() /Users/mfarmer/.composer/vendor/laravel/installer/src/NewCommand.php:34
```
