### PR TITLE
Remove composer.lock from .gitignore as a part of the build.

### DIFF
--- a/zipper.sh
+++ b/zipper.sh
@@ -2,6 +2,7 @@ wget https://github.com/laravel/laravel/archive/master.zip
 unzip master.zip -d working
 cd working/laravel-master
 composer install
+awk '!/composer.lock/' .gitignore > temp && mv temp .gitignore
 zip -r ../../laravel-craft.zip .
 cd ../..
 mv laravel-craft.zip public/laravel-craft.zip


### PR DESCRIPTION
Not sure what you think about this, Taylor, but I know people have asked about removing `composer.lock` from `.gitignore` often (e.g. https://github.com/laravel/laravel/pull/3019). I know we keep it in because it's good for the framework, but I figured this build step could help start projects out on the right foot.

Only problem is it now creates an inconsistency--projects installed via the installer get it removed, those installed with composer create-project don't.

Just wanted to suggest it, though, and see what you think.

I tried this with `sed` but had some trouble with it. Theoretically it should've (I think) been:

```
sed -i '/composer\.phar/d' ./.gitignore
```