### PR TITLE
Fix unreported error in execute

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -35,7 +35,9 @@ class NewCommand extends \Symfony\Component\Console\Command\Command {
 		);
 
 		$output->writeln('<info>Crafting application...</info>');
-
+		
+		$directory = $input->getArgument('name');
+		
 		$this->download($zipFile = $this->makeFilename())
              ->extract($zipFile, $directory)
              ->cleanUp($zipFile);


### PR DESCRIPTION
Previously, running `laravel new <directory>` executed without actually extracting the downloaded zip archive to the supplied directory, as the supplied directory was never read.