### PR TITLE
Duplicate .env.example for new apps.

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -40,6 +40,8 @@ class NewCommand extends \Symfony\Component\Console\Command\Command {
              ->extract($zipFile, $directory)
              ->cleanUp($zipFile);
 
+		copy($directory.'/.env.example', $directory.'/.env');
+
 		$output->writeln('<comment>Application ready! Build something amazing.</comment>');
 	}
 


### PR DESCRIPTION
When installing via Composer, it automatically duplicates the .env.example file. Now the Laravel installer does too.

This addition has been tested.