### PR TITLE
Allowing crafting in an empty dir

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -3,6 +3,7 @@
 use ZipArchive;
 use RuntimeException;
 use GuzzleHttp\Client;
+use FilesystemIterator;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -67,7 +68,7 @@ class NewCommand extends Command
      */
     protected function verifyApplicationDoesntExist($directory, OutputInterface $output)
     {
-        if (is_dir($directory)) {
+        if (is_dir($directory) && (new FilesystemIterator($directory))->valid()) {
             throw new RuntimeException('Application already exists!');
         }
     }


### PR DESCRIPTION
Right now the script doesn't allow crafting a new Laravel application into an empty directory – it throws an exception if the dir exists. I've added a check to enable this. 

With this change, these commands (which I tend to use) will work fine:

```
mkdir blog
cd blog
laravel new .
```