### PR TITLE
Keep symbolic links in zip

### DIFF
--- a/zipper.sh
+++ b/zipper.sh
@@ -2,7 +2,7 @@ wget https://github.com/laravel/laravel/archive/master.zip
 unzip master.zip -d working
 cd working/laravel-master
 composer install
-zip -r ../../laravel-craft.zip .
+zip -ry ../../laravel-craft.zip .
 cd ../..
 mv laravel-craft.zip public/laravel-craft.zip
 rm -rf working


### PR DESCRIPTION
The files in ```vendor/bin``` or symbolic linked.

Use the -y  for ```zip``` will keep the symbolic links.

Otherwise this will produce an error:
```sh
php laravel new test-app
cd test-app/vendor/bin
php ./phpunit
```