### PR TITLE
Call composer command to copy .env file

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -47,6 +47,7 @@ class NewCommand extends Command
 
         $commands = [
             $composer.' run-script post-install-cmd',
+            $composer.' run-script post-root-package-install',
             $composer.' run-script post-create-project-cmd',
         ];
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -46,8 +46,8 @@ class NewCommand extends Command
         $composer = $this->findComposer();
 
         $commands = [
-            $composer.' run-script post-install-cmd',
             $composer.' run-script post-root-package-install',
+            $composer.' run-script post-install-cmd',
             $composer.' run-script post-create-project-cmd',
         ];
 


### PR DESCRIPTION
If you run the installer to create a new project it says the
Application key was set successfully even though it wasn't.

This calls the composer script to copy .env.example to .env, so the
next script that calls artisan key:generate will work.

The reason for the current behavior is that php artisan key:generate
doesn't display an error if it fails to find a .env file.