### PR TITLE
Check if the given folder are empty before to install.

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -65,6 +65,7 @@ class NewCommand extends Command
 
     /**
      * Verify that the application does not already exist.
+     * Check if given directory is not empty.
      *
      * @param  string  $directory
      * @return void
@@ -72,7 +73,9 @@ class NewCommand extends Command
     protected function verifyApplicationDoesntExist($directory, OutputInterface $output)
     {
         if (is_dir($directory)) {
-            throw new RuntimeException('Application already exists!');
+            if (array_diff(scandir($directory), ['.', '..'])) {
+                throw new RuntimeException('Application already exists!');
+            }
         }
     }
 


### PR DESCRIPTION
It's just an additional condition to check if given folder are empty or not.
If the given folder (that could be *"."*) is empty, *installer* can craft the Laravel application there.
With that you can run something like:
`$ laravel new .`

Also I'm considering that the RuntimeException should say: **"Folder is not empty"** instead of "Application already exists!". But is not part of this PR. 

Let me know your thoughts.