### PR TITLE
Implement lts command for 5.1 LTS project.

### DIFF
--- a/laravel
+++ b/laravel
@@ -7,7 +7,8 @@ if (file_exists(__DIR__.'/../../autoload.php')) {
     require __DIR__.'/vendor/autoload.php';
 }
 
-$app = new Symfony\Component\Console\Application('Laravel Installer', '1.2.2');
+$app = new Symfony\Component\Console\Application('Laravel Installer', '1.2.3');
 $app->add(new Laravel\Installer\Console\NewCommand);
+$app->add(new Laravel\Installer\Console\LtsCommand);
 
 $app->run();

--- a/src/LtsCommand.php
+++ b/src/LtsCommand.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Laravel\Installer\Console;
+
+use ZipArchive;
+use RuntimeException;
+use GuzzleHttp\Client;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class LtsCommand extends Command
+{
+    /**
+     * Configure the command options.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('lts')
+            ->setDescription('Create a new Laravel 5.1 LTS application.')
+            ->addArgument('name', InputArgument::REQUIRED);
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @param  InputInterface  $input
+     * @param  OutputInterface  $output
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->verifyApplicationDoesntExist(
+            $directory = getcwd().'/'.$input->getArgument('name'),
+            $output
+        );
+
+        $output->writeln('<info>Crafting application...</info>');
+
+        $this->download($zipFile = $this->makeFilename())
+             ->extract($zipFile, $directory)
+             ->cleanUp($zipFile);
+
+        $composer = $this->findComposer();
+
+        $commands = [
+            $composer.' run-script post-root-package-install',
+            $composer.' run-script post-install-cmd',
+            $composer.' run-script post-create-project-cmd',
+        ];
+
+        $process = new Process(implode(' && ', $commands), $directory, null, null, null);
+
+        $process->run(function ($type, $line) use ($output) {
+            $output->write($line);
+        });
+
+        $output->writeln('<comment>Application ready! Build something amazing.</comment>');
+    }
+
+    /**
+     * Verify that the application does not already exist.
+     *
+     * @param  string  $directory
+     * @return void
+     */
+    protected function verifyApplicationDoesntExist($directory, OutputInterface $output)
+    {
+        if (is_dir($directory)) {
+            throw new RuntimeException('Application already exists!');
+        }
+    }
+
+    /**
+     * Generate a random temporary filename.
+     *
+     * @return string
+     */
+    protected function makeFilename()
+    {
+        return getcwd().'/laravel_'.md5(time().uniqid()).'.zip';
+    }
+
+    /**
+     * Download the temporary Zip to the given file.
+     *
+     * @param  string  $zipFile
+     * @return $this
+     */
+    protected function download($zipFile)
+    {
+        $response = (new Client)->get('http://cabinet.laravel.com/latest-lts.zip');
+
+        file_put_contents($zipFile, $response->getBody());
+
+        return $this;
+    }
+
+    /**
+     * Extract the zip file into the given directory.
+     *
+     * @param  string  $zipFile
+     * @param  string  $directory
+     * @return $this
+     */
+    protected function extract($zipFile, $directory)
+    {
+        $archive = new ZipArchive;
+
+        $archive->open($zipFile);
+
+        $archive->extractTo($directory);
+
+        $archive->close();
+
+        return $this;
+    }
+
+    /**
+     * Clean-up the Zip file.
+     *
+     * @param  string  $zipFile
+     * @return $this
+     */
+    protected function cleanUp($zipFile)
+    {
+        @chmod($zipFile, 0777);
+
+        @unlink($zipFile);
+
+        return $this;
+    }
+
+    /**
+     * Get the composer command for the environment.
+     *
+     * @return string
+     */
+    protected function findComposer()
+    {
+        if (file_exists(getcwd().'/composer.phar')) {
+            return '"'.PHP_BINARY.'" composer.phar';
+        }
+
+        return 'composer';
+    }
+}


### PR DESCRIPTION
Ref: laravel/laravel#11002

Implement lts command for 5.1 LTS project.

```
$> diff -u src/NewCommand.php src/LtsCommand.php  
--- src/NewCommand.php  2015-12-03 07:11:59.601960231 +0900
+++ src/LtsCommand.php  2015-12-03 07:19:23.960293175 +0900
@@ -11,7 +11,7 @@
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class NewCommand extends Command
+class LtsCommand extends Command
 {
     /**
      * Configure the command options.
@@ -21,8 +21,8 @@
     protected function configure()
     {
         $this
-            ->setName('new')
-            ->setDescription('Create a new Laravel application.')
+            ->setName('lts')
+            ->setDescription('Create a new Laravel 5.1 LTS application.')
             ->addArgument('name', InputArgument::REQUIRED);
     }
 
@@ -94,7 +94,7 @@
      */
     protected function download($zipFile)
     {
-        $response = (new Client)->get('http://cabinet.laravel.com/latest.zip');
+        $response = (new Client)->get('http://cabinet.laravel.com/latest-lts.zip');
 
         file_put_contents($zipFile, $response->getBody());
```

zipper.sh made Zip file. However generated file has different name with in NewCommand class. ( 'laravel-craft.zip' in zipper.sh, but 'latest.zip' in download method of NewCommnad. So I suspected @taylorotwell has another work flow to create latest zip file, or zipper.sh is old.

Anyway it will need to change work flow up upload/generate zip files to 'cabinet.laravel.com' before accepted this pull request.

TODO: After accepted this pull request, there is need to change 'installtion' page for version 5.1 in document.