### PR TITLE
Use Alchemy/Zippy instead of ZipArchive to maintain permissions/symlinks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "require": {
         "guzzlehttp/guzzle": "~4.0|~5.0|~6.0",
         "symfony/console": "~2.3|~3.0",
-        "symfony/process": "~2.3|~3.0"
+        "symfony/process": "~2.3|~3.0",
+        "alchemy/zippy": "~0.3"
     },
     "bin": [
         "laravel"

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,136 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d4c1de400ec0ea552ab8d3064386d686",
-    "content-hash": "70c155d8bc1293c13b6e57882bdb0811",
+    "hash": "53ce3fd9b476f7e8e7ccb176f72111ad",
+    "content-hash": "852cd7b120d6ed8be901c16faea582ef",
     "packages": [
+        {
+            "name": "alchemy/zippy",
+            "version": "0.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/alchemy-fr/Zippy.git",
+                "reference": "b73ba0c1ff5fc525bc69103960379e77712cc633"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/alchemy-fr/Zippy/zipball/b73ba0c1ff5fc525bc69103960379e77712cc633",
+                "reference": "b73ba0c1ff5fc525bc69103960379e77712cc633",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/collections": "~1.0",
+                "php": ">=5.3.3",
+                "symfony/filesystem": "^2.0.5|^3.0",
+                "symfony/process": "^2.1|^3.0"
+            },
+            "require-dev": {
+                "ext-zip": "*",
+                "guzzle/guzzle": "~3.0",
+                "phpunit/phpunit": "^4.0|^5.0",
+                "symfony/finder": "^2.0.5|^3.0"
+            },
+            "suggest": {
+                "ext-zip": "To use the ZipExtensionAdapter",
+                "guzzle/guzzle": "To use the GuzzleTeleporter"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Alchemy\\Zippy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alchemy",
+                    "email": "dev.team@alchemy.fr",
+                    "homepage": "http://www.alchemy.fr/"
+                }
+            ],
+            "description": "Zippy, the archive manager companion",
+            "keywords": [
+                "bzip",
+                "compression",
+                "tar",
+                "zip"
+            ],
+            "time": "2015-12-15 11:29:00"
+        },
+        {
+            "name": "doctrine/collections",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "6c1e4eef75f310ea1b3e30945e9f06e652128b8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/6c1e4eef75f310ea1b3e30945e9f06e652128b8a",
+                "reference": "6c1e4eef75f310ea1b3e30945e9f06e652128b8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Collections\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Collections Abstraction library",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "array",
+                "collections",
+                "iterator"
+            ],
+            "time": "2015-04-14 22:21:58"
+        },
         {
             "name": "guzzlehttp/guzzle",
             "version": "6.1.1",
@@ -286,6 +413,55 @@
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
             "time": "2015-11-30 12:36:17"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "692d98d813e4ef314b9c22775c86ddbeb0f44884"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/692d98d813e4ef314b9c22775c86ddbeb0f44884",
+                "reference": "692d98d813e4ef314b9c22775c86ddbeb0f44884",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-11-23 10:41:47"
         },
         {
             "name": "symfony/polyfill-mbstring",

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Installer\Console;
 
-use ZipArchive;
+use Alchemy\Zippy\Zippy;
 use RuntimeException;
 use GuzzleHttp\Client;
 use Symfony\Component\Process\Process;
@@ -125,13 +125,13 @@ class NewCommand extends Command
      */
     protected function extract($zipFile, $directory)
     {
-        $archive = new ZipArchive;
+        $zippy = Zippy::load();
 
-        $archive->open($zipFile);
+        $archive = $zippy->open($zipFile);
 
-        $archive->extractTo($directory);
+        mkdir($directory);
 
-        $archive->close();
+        $archive->extract($directory);
 
         return $this;
     }


### PR DESCRIPTION
When executing the `laravel new` command currently, ZipArchive does not maintain permissions on executables (such as `artisan`), nor does it [keep symlinks](https://bugs.php.net/bug.php?id=46013), such as those within `vendor/bin`. Things like `phpunit` will fail to run in this instance.

```
$ vendor/bin/phpunit
You need to set up the project dependencies using the following commands:
wget http://getcomposer.org/composer.phar
php composer.phar install
```

This means you currently have to manually remove the `vendor` directory, then run `composer install`, as well as manually set the permissions on the `artisan` command.

Given running the command should be quick, I opted for a different mechanism when inflating the archive, rather than removing `vendor` and running a `composer install`, which still doesn't address the `artisan` permissions issue.

This works nicely when I use a locally available zip file generated with `zipper.sh`, however, using the archive from the [Laravel cabinet](http://cabinet.laravel.com/latest.zip) still pulls in copied binary files, rather than the necessary symlinks. I suspect this has something to do with how the zip is generated, as manually running `unzip latest.zip -d testing` and checking the files in `vendor/bin` reveals them as having 775 permissions, rather than being symlinks.

**Pulling from cabinet.laravel.com with ZipArchive**
```
~/Development/laravel-installer $ ./laravel new testing 
~/Development/laravel-installer $ ll testing/vendor/bin
total 40
-rw-r--r--  1 michaeld  staff   4.9K 22 Dec 11:09 php-parse
-rw-r--r--  1 michaeld  staff   1.1K 22 Dec 11:09 phpunit
-rw-r--r--  1 michaeld  staff   4.0K 22 Dec 11:09 psysh
```

**Pulling from local copy of latest.zip generated with zipper.sh with ZipArchive**
```
~/Development/laravel-installer $ ./laravel new testing 
~/Development/laravel-installer $ ll testing/vendor/bin
total 24
-rw-r--r--  1 michaeld  staff    33B 22 Dec 11:10 php-parse
-rw-r--r--  1 michaeld  staff    26B 22 Dec 11:10 phpunit
-rw-r--r--  1 michaeld  staff    22B 22 Dec 11:10 psysh
```

**Pulling from cabinet.laravel.com with Alchemy\Zippy**

```
~/Development/laravel-installer $ ./laravel new testing 
~/Development/laravel-installer $ ll testing/vendor/bin
total 40
-rwxrwxr-x  1 michaeld  staff   4.9K  5 Dec 01:58 php-parse
-rwxrwxr-x  1 michaeld  staff   1.1K 12 Dec 18:15 phpunit
-rwxrwxr-x  1 michaeld  staff   4.0K 13 Nov 02:48 psysh
```

**Pulling from local copy of latest.zip generated with zipper.sh with Alchemy\Zippy**

```
~/Development/laravel-installer $ ./laravel new testing
~/Development/laravel-installer $ ll testing/vendor/bin
total 24
lrwxr-xr-x  1 michaeld  staff    33B 22 Dec 11:07 php-parse -> ../nikic/php-parser/bin/php-parse
lrwxr-xr-x  1 michaeld  staff    26B 22 Dec 11:07 phpunit -> ../phpunit/phpunit/phpunit
lrwxr-xr-x  1 michaeld  staff    22B 22 Dec 11:07 psysh -> ../psy/psysh/bin/psysh
```