### PR TITLE
Allow install on empty directories

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -88,7 +88,7 @@ class NewCommand extends Command
             throw new RuntimeException('Application already exists!');
         }
     }
-    
+
     /**
      * Check whether the directory is completely empty.
      *

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -84,13 +84,13 @@ class NewCommand extends Command
      */
     protected function verifyApplicationDoesntExist($directory, OutputInterface $output)
     {
-        if (is_dir($directory) && !$this->isDirEmpty($directory)) {
+        if (is_dir($directory) && ! $this->isDirEmpty($directory)) {
             throw new RuntimeException('Application already exists!');
         }
     }
     
     /**
-     * Check whether the directory is completely empty
+     * Check whether the directory is completely empty.
      *
      * @param  string  $directory
      * @return bool
@@ -98,7 +98,7 @@ class NewCommand extends Command
     protected function isDirEmpty($directory)
     {
         $expected = ['.', '..'];
-        
+
         return scandir($directory) === $expected;
     }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -84,9 +84,22 @@ class NewCommand extends Command
      */
     protected function verifyApplicationDoesntExist($directory, OutputInterface $output)
     {
-        if (is_dir($directory)) {
+        if (is_dir($directory) && !$this->isDirEmpty($directory)) {
             throw new RuntimeException('Application already exists!');
         }
+    }
+    
+    /**
+     * Check whether the directory is completely empty
+     *
+     * @param  string  $directory
+     * @return bool
+     */
+    protected function isDirEmpty($directory)
+    {
+        $expected = ['.', '..'];
+        
+        return scandir($directory) === $expected;
     }
 
     /**


### PR DESCRIPTION
There have been a fair few times where I have created my directory before hand (eg. Shared / Synced folder in vagrant), where it is tricky to `rm -rf $directory`, but the directory is completely empty. Currently, because it is a directory, it throws an exception, but install should be fine if the folder is clean.