### PR TITLE
Throw error if a file exists with that name

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -87,6 +87,10 @@ class NewCommand extends Command
         if (is_dir($directory)) {
             throw new RuntimeException('Application already exists!');
         }
+
+        if (is_file($directory)) {
+            throw new RuntimeException('Cannot make an Application with that name due to a naming conflict!');
+        }
     }
 
     /**


### PR DESCRIPTION
Currently there is only checks for if a directory exists with that name, however, we don't check whether a file exists with the name. If it does, then you get a ZipArchive error:

![image](https://cloud.githubusercontent.com/assets/842974/14156387/15c79da2-f6be-11e5-8464-51da4541c2d0.png)

