### PR TITLE
Respect --no-ansi option

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -62,7 +62,13 @@ class NewCommand extends Command
             $composer.' run-script post-install-cmd',
             $composer.' run-script post-create-project-cmd',
         ];
-
+        
+        if ($input->getOption('no-ansi')) {
+            $commands = array_map(function ($value) {
+                return $value . ' --no-ansi';
+            }, $commands);
+        }
+        
         $process = new Process(implode(' && ', $commands), $directory, null, null, null);
 
         if ('\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -65,7 +65,7 @@ class NewCommand extends Command
         
         if ($input->getOption('no-ansi')) {
             $commands = array_map(function ($value) {
-                return $value . ' --no-ansi';
+                return $value.' --no-ansi';
             }, $commands);
         }
         

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -62,13 +62,13 @@ class NewCommand extends Command
             $composer.' run-script post-install-cmd',
             $composer.' run-script post-create-project-cmd',
         ];
-        
+
         if ($input->getOption('no-ansi')) {
             $commands = array_map(function ($value) {
                 return $value.' --no-ansi';
             }, $commands);
         }
-        
+
         $process = new Process(implode(' && ', $commands), $directory, null, null, null);
 
         if ('\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {


### PR DESCRIPTION
Makes laravel  `--no-ansi` be respected, even when showing the result of the composer command.