### PR TITLE
require zip extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         }
     },
     "require": {
+        "ext-zip": "*",
         "guzzlehttp/guzzle": "~4.0|~5.0|~6.0",
         "symfony/console": "~2.3|~3.0",
         "symfony/process": "~2.3|~3.0"


### PR DESCRIPTION
If the Zip PHP extension is not installed, create a new project its impossible, the use of this module its useless... should be require...