### PR TITLE
Switch installer to use GitHub zips

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -122,7 +122,7 @@ class NewCommand extends Command
                 $filename = 'latest.zip';
                 break;
             default:
-                $filename = 'latest-' . $version . '.zip';
+                $filename = 'latest-'.str_rpelace('.', '', $version).'.zip';
                 break;
         }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -122,7 +122,7 @@ class NewCommand extends Command
                 $filename = 'latest.zip';
                 break;
             default:
-                $filename = 'latest-'.str_rpelace('.', '', $version).'.zip';
+                $filename = 'latest-'.str_replace('.', '', $version).'.zip';
                 break;
         }
 


### PR DESCRIPTION
This all started with: https://larachat.slack.com/archives/laravel5/p1485514747011330

Then I found the `--5.2` option didn't work at all anymore.

Decided to switch to GitHub's zips and simplified the command.

Result: can now install any defined branch from GitHub using the installer by using the new `--ver` command, e.g.:

    laravel new my-project-name --ver=5.3

Hope this is acceptable - I haven't checked whether it's allowed etc on GitHub's TOS 😅 