### PR TITLE
Add --force option to ignore existing directory in new command

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -25,7 +25,8 @@ class NewCommand extends Command
             ->setName('new')
             ->setDescription('Create a new Laravel application.')
             ->addArgument('name', InputArgument::OPTIONAL)
-            ->addOption('dev', null, InputOption::VALUE_NONE, 'Installs the latest "development" release');
+            ->addOption('dev', null, InputOption::VALUE_NONE, 'Installs the latest "development" release')
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Forces install even if the directory already exists');
     }
 
     /**
@@ -41,9 +42,11 @@ class NewCommand extends Command
             throw new RuntimeException('The Zip PHP extension is not installed. Please install it and try again.');
         }
 
-        $this->verifyApplicationDoesntExist(
-            $directory = ($input->getArgument('name')) ? getcwd().'/'.$input->getArgument('name') : getcwd()
-        );
+        $directory = ($input->getArgument('name')) ? getcwd().'/'.$input->getArgument('name') : getcwd();
+
+        if (! $input->getOption('force')) {
+            $this->verifyApplicationDoesntExist($directory);
+        }
 
         $output->writeln('<info>Crafting application...</info>');
 


### PR DESCRIPTION
When you already have an existing directory under source control and want to install laravel to it, it can be a little bit tedious since the installer wont write to an existing directory.

To handle this use case, a --force option is provided which ignores if the directory already exists and proceeds to install to that directory.