### PR TITLE
Set permissions for directories that need to be writable by server

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "ext-zip": "*",
         "guzzlehttp/guzzle": "~4.0|~5.0|~6.0",
         "symfony/console": "~2.3|~3.0",
-        "symfony/process": "~2.3|~3.0"
+        "symfony/process": "~2.3|~3.0",
+        "symfony/filesystem": "^3.3"
     },
     "bin": [
         "laravel"

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         "ext-zip": "*",
         "guzzlehttp/guzzle": "~4.0|~5.0|~6.0",
         "symfony/console": "~2.3|~3.0",
-        "symfony/process": "~2.3|~3.0",
-        "symfony/filesystem": "^3.3"
+        "symfony/filesystem": "~2.3|~3.0",
+        "symfony/process": "~2.3|~3.0"
     },
     "bin": [
         "laravel"

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -188,8 +188,8 @@ class NewCommand extends Command
         $fs = new Filesystem();
 
         try {
-            $fs->chmod($appDirectory . DIRECTORY_SEPARATOR . "bootstrap/cache", 0777, 0000, true);
-            $fs->chmod($appDirectory . DIRECTORY_SEPARATOR . "storage", 0777, 0000, true);
+            $fs->chmod($appDirectory . DIRECTORY_SEPARATOR . "bootstrap/cache", 0755, 0000, true);
+            $fs->chmod($appDirectory . DIRECTORY_SEPARATOR . "storage", 0755, 0000, true);
         } catch (IOExceptionInterface $e) {
             $output->writeln('<question>Verify that the storage and bootstrap/cache directories are writable.</question>');
         }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -6,11 +6,14 @@ use ZipArchive;
 use RuntimeException;
 use GuzzleHttp\Client;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
+
 
 class NewCommand extends Command
 {
@@ -54,6 +57,7 @@ class NewCommand extends Command
 
         $this->download($zipFile = $this->makeFilename(), $version)
              ->extract($zipFile, $directory)
+             ->prepareWritableDirectories($directory, $output)
              ->cleanUp($zipFile);
 
         $composer = $this->findComposer();
@@ -169,6 +173,26 @@ class NewCommand extends Command
         @chmod($zipFile, 0777);
 
         @unlink($zipFile);
+
+        return $this;
+    }
+
+    /**
+     * Make sure the storage and bootstrap cache directories are writable
+     * @param  string  $appDirectory
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return $this
+     */
+    protected function prepareWritableDirectories($appDirectory, OutputInterface $output)
+    {
+        $fs = new Filesystem();
+
+        try {
+            $fs->chmod($appDirectory . DIRECTORY_SEPARATOR . "bootstrap/cache", 0777, 0000, true);
+            $fs->chmod($appDirectory . DIRECTORY_SEPARATOR . "storage", 0777, 0000, true);
+        } catch (IOExceptionInterface $e) {
+            $output->writeln('<question>Verify that the storage and bootstrap/cache directories are writable.</question>');
+        }
 
         return $this;
     }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -14,7 +14,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 
-
 class NewCommand extends Command
 {
     /**
@@ -178,7 +177,8 @@ class NewCommand extends Command
     }
 
     /**
-     * Make sure the storage and bootstrap cache directories are writable
+     * Make sure the storage and bootstrap cache directories are writable.
+     * 
      * @param  string  $appDirectory
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @return $this


### PR DESCRIPTION
I find my self having to manually set the permissions on the `storage` and `bootstrap/cache` folders after each new install. Would be nice if it the installer at least attempts to do this automatically and gives a nice reminder if it can't. My first Laravel PR
Huge fan.