### PR TITLE
Avoid composer.lock break on old php versions

### DIFF
--- a/zipper.sh
+++ b/zipper.sh
@@ -3,6 +3,7 @@ wget https://github.com/laravel/laravel/archive/master.zip
 unzip master.zip -d working
 cd working/laravel-master
 composer install
+rm composer.lock
 zip -ry ../../laravel-craft.zip .
 cd ../..
 mv laravel-craft.zip public/laravel-craft.zip


### PR DESCRIPTION
Tries to solve https://github.com/laravel/framework/issues/20214 with another approach.

As was tested [here](https://github.com/laravel/framework/pull/20241#issuecomment-317564201) composer correctly handle doctrine/inflector version with the `~1.0` constraint.

Increase doctrine/inflector to `1.1.*` will keep it locker even if we are running PHP 7.1 and we can't have the benefit of newer minor version of  doctrine/inflector. 

The real problem resides in `laravel new` zipping a newer composer.lock, as stated in [doctrine release note](http://www.doctrine-project.org/2017/07/25/php-7.1-requirement-and-composer.html)

> A common problem is people running a newer PHP version on their developer machines than on their production servers. In this case, running composer update on a developer machine (with PHP 7.1) might happily pull in an update that simply won’t work when deployed on a production machine running PHP 5.6.

In this case, read *developer machine* as the builder machine that run ` zipper.sh` and *production machine* as the developer machine running an older php version

Related:
https://github.com/laravel/framework/issues/20214
http://www.doctrine-project.org/2017/07/25/php-7.1-requirement-and-composer.html