### PR TITLE
Create composer.lock as minimun required platform

### DIFF
--- a/zipper.sh
+++ b/zipper.sh
@@ -2,6 +2,7 @@
 wget https://github.com/laravel/laravel/archive/master.zip
 unzip master.zip -d working
 cd working/laravel-master
+composer config platform.php 5.6.4
 composer install
 zip -ry ../../laravel-craft.zip .
 cd ../..


### PR DESCRIPTION
Create composer.lock emulating minimum PHP version for Laravel 5.4 avoid errors like the reported here https://github.com/laravel/framework/issues/20214 , keeps the lock file for faster installations and allow to [relax dependencies constraint again](https://github.com/laravel/framework/pull/20259).

@taylorotwell is this `.sh` still used to generate http://cabinet.laravel.com/ files? It's not used on NewCommand as far I know.

Related:
https://getcomposer.org/doc/03-cli.md#config
https://getcomposer.org/doc/06-config.md#platform
https://github.com/laravel/framework/issues/20214
https://github.com/laravel/framework/pull/20241#issuecomment-317564201
https://github.com/laravel/installer/pull/68
