### PR TITLE
Update findComposer function

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -221,6 +221,8 @@ class NewCommand extends Command
     {
         if (file_exists(getcwd().'/composer.phar')) {
             return '"'.PHP_BINARY.'" composer.phar';
+        } elseif (file_exists($_SERVER['HOME']).'/composer.phar') {
+            return '"'.PHP_BINARY.'" "'.$_SERVER['HOME'].'/composer.phar"';
         }
 
         return 'composer';


### PR DESCRIPTION
Changed findComposer function to check if there is a composer.phar file inside the HOME dir "~/composer.phar". Some CPanel installations keep older composer version when updating and laravel installer uses the old versions to run through. Check https://github.com/laravel/framework/issues/20864#issuecomment-350477997 for more information