### PR TITLE
Updated findComposer function to work with composer.phar installed at home dir

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -221,7 +221,7 @@ class NewCommand extends Command
     {
         if (file_exists(getcwd().'/composer.phar')) {
             return '"'.PHP_BINARY.'" composer.phar';
-        } elseif (file_exists($_SERVER['HOME']).'/composer.phar') {
+        } elseif (file_exists($_SERVER['HOME'].'/composer.phar')) {
             return '"'.PHP_BINARY.'" "'.$_SERVER['HOME'].'/composer.phar"';
         }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -221,6 +221,8 @@ class NewCommand extends Command
     {
         if (file_exists(getcwd().'/composer.phar')) {
             return '"'.PHP_BINARY.'" composer.phar';
+        } elseif (file_exists($_SERVER['HOME']).'/composer.phar') {
+            return '"'.PHP_BINARY.'" "'.$_SERVER['HOME'].'/composer.phar"';
         }
 
         return 'composer';


### PR DESCRIPTION
Changed findComposer function to check if there is a composer.phar file inside the HOME dir "~/composer.phar". Some CPanel installations keep older composer version when updating and laravel installer uses the old versions to run through. Check laravel/framework#20864 (comment) for more information. 

Previous pull request closed because of a mistype that had the `file_exists` function to just check the `$_SERVER['HOME']` without concating the `'/composer.phar'` inside the function after the home dir.