### PR TITLE
Remove duplicated command

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -70,8 +70,6 @@ class NewCommand extends Command
 
         if ($input->getOption('dev')) {
             unset($commands[2]);
-
-            $commands[] = $composer.' run-script post-autoload-dump';
         }
 
         if ($input->getOption('no-ansi')) {

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -68,10 +68,6 @@ class NewCommand extends Command
             $composer.' run-script post-autoload-dump',
         ];
 
-        if ($input->getOption('dev')) {
-            unset($commands[2]);
-        }
-
         if ($input->getOption('no-ansi')) {
             $commands = array_map(function ($value) {
                 return $value.' --no-ansi';


### PR DESCRIPTION
Unless I'm missing something obvious there should be no need to run `post-autoload-dump` a second time for dev.