### PR TITLE
Remove final full stop to make description consistent

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -25,7 +25,7 @@ class NewCommand extends Command
     {
         $this
             ->setName('new')
-            ->setDescription('Create a new Laravel application.')
+            ->setDescription('Create a new Laravel application')
             ->addArgument('name', InputArgument::OPTIONAL)
             ->addOption('dev', null, InputOption::VALUE_NONE, 'Installs the latest "development" release')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Forces install even if the directory already exists');


### PR DESCRIPTION
The other available commands and general output don't include a final full stop, only this one does.

![image](https://user-images.githubusercontent.com/1100408/36125856-eebe548c-10a9-11e8-8ee2-d1e2945f2fa0.png)

I know it's not a big deal but just spotted it this morning. For reference it's probably worth pointing out the all the built-in commands with a fresh Laravel app omit the final full stop as well.