### PR TITLE
Respect --quiet option

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -74,6 +74,12 @@ class NewCommand extends Command
             }, $commands);
         }
 
+        if ($input->getOption('quiet')) {
+            $commands = array_map(function ($value) {
+                return $value.' --quiet';
+            }, $commands);
+        }
+
         $process = new Process(implode(' && ', $commands), $directory, null, null, null);
 
         if ('\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {


### PR DESCRIPTION
## What

The usage info for the installer says that the `--quiet` option can be used to prevent if from outputting things:

```
Usage:
  new [options] [--] [<name>]

Arguments:
  name

Options:
  [...]
  -q, --quiet           Do not output any message
  [...]
```

However, this option is not honored, because it is never passed to Composer.

Similarly to what has been done in #52 for `--no-ansi`, this PR ensures that Composer is made aware of this option.

## Use case

I’m using the Laravel installer as part as a script, to automate the creation of Laravel projects and tweak additional things. I would like to prevent the installer from outputting anything, so that its messages do not interfere with the ones coming from my script.