### PR TITLE
Update NewCommand.php

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -40,7 +40,7 @@ class NewCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (! class_exists('ZipArchive')) {
+        if (! extension_loaded('zip')) {
             throw new RuntimeException('The Zip PHP extension is not installed. Please install it and try again.');
         }
 


### PR DESCRIPTION
use the `extension_loaded` method to check if the 'zip' extension is loaded rather than checking for a class in the extension.

while probably an edge case, there could be a user defined `\ZipArchive` class that would cause this conditional to pass, even when the extension is not loaded.

http://php.net/manual/en/function.extension-loaded.php