### PR TITLE
Replace database name with the name of the app

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -81,7 +81,7 @@ class NewCommand extends Command
             }, $commands);
         }
         
-        $commands[] = "sed -i '' 's/DB_DATABASE=homestead/DB_DATABASE={$name}/g' .env";
+        $commands[] = "sed -i '' 's/DB_DATABASE=homestead/DB_DATABASE={$name}/g' .env .env.example";
 
         $process = new Process(implode(' && ', $commands), $directory, null, null, null);
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -43,8 +43,9 @@ class NewCommand extends Command
         if (! extension_loaded('zip')) {
             throw new RuntimeException('The Zip PHP extension is not installed. Please install it and try again.');
         }
-
-        $directory = ($input->getArgument('name')) ? getcwd().'/'.$input->getArgument('name') : getcwd();
+        
+        $name = $input->getArgument('name');
+        $directory = $name ? getcwd().'/'.$name : getcwd();
 
         if (! $input->getOption('force')) {
             $this->verifyApplicationDoesntExist($directory);
@@ -79,6 +80,8 @@ class NewCommand extends Command
                 return $value.' --quiet';
             }, $commands);
         }
+        
+        $commands[] = "sed -i '' 's/DB_DATABASE=homestead/DB_DATABASE={$name}/g' .env";
 
         $process = new Process(implode(' && ', $commands), $directory, null, null, null);
 


### PR DESCRIPTION
This PR updates the `DB_DATABASE` value in `.env` and `.env.example` to the given name of the app. This is one of the first things I do when I create a new Laravel project and I thought it would be great if the installer did it for me. I think most developers have more than one project installed locally, so `homestead` will almost always be replaced.