### PR TITLE
Update composer path on findComposer

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -219,8 +219,10 @@ class NewCommand extends Command
      */
     protected function findComposer()
     {
-        if (file_exists(getcwd().'/composer.phar')) {
-            return '"'.PHP_BINARY.'" composer.phar';
+        $composerPath = getcwd().'/composer.phar';
+
+        if (file_exists($composerPath)) {
+            return '"'.PHP_BINARY.'" '.$composerPath;
         }
 
         return 'composer';


### PR DESCRIPTION
Reopen PR #85.

# Changed log
- Update the composer execution path on `NewCommand::findComposer` command.

Actually, the original `php compoer.phar` string result is not correct.

And this will not specify the current path to let PHP binary know where the `composer.phar` can execute.

It should use the current `composer` path to tell PHP binary to execute `composer.phar`.

# Instruction

## Environment
- Ubuntu 18.04
- composer version is `1.8.4`.

Here are steps about reproducing the issue.

- Firstly, we use the `composer require laravel/installer` command.
- Then using the `vendor/bin/laravel new blog` to create the new Laravel project.
- It will get the error message in following image during building the Laravel project.

![image](https://user-images.githubusercontent.com/9021747/54450540-98bc1500-478b-11e9-9e33-cb363c496dce.png)
