### PR TITLE
Replace database name with the name of the app

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -43,8 +43,9 @@ class NewCommand extends Command
         if (! extension_loaded('zip')) {
             throw new RuntimeException('The Zip PHP extension is not installed. Please install it and try again.');
         }
-
-        $directory = ($input->getArgument('name')) ? getcwd().'/'.$input->getArgument('name') : getcwd();
+        
+        $name = $input->getArgument('name');
+        $directory = $name ? getcwd().'/'.$name : getcwd();
 
         if (! $input->getOption('force')) {
             $this->verifyApplicationDoesntExist($directory);
@@ -89,6 +90,9 @@ class NewCommand extends Command
         $process->run(function ($type, $line) use ($output) {
             $output->write($line);
         });
+        
+        $this->replaceDefaultDatabase("{$directory}/.env", $name);
+        $this->replaceDefaultDatabase("{$directory}/.env.example", $name);
 
         $output->writeln('<comment>Application ready! Build something amazing.</comment>');
     }
@@ -224,5 +228,20 @@ class NewCommand extends Command
         }
 
         return 'composer';
+    }
+    
+    /**
+     * Replaces the default database name with the given name.
+     *
+     * @param  string  $path
+     * @param  string  $database
+     * @return void
+     */
+    protected function replaceDefaultDatabase($path, $database)
+    {
+        file_put_contents(
+            $path,
+            str_replace("DB_DATABASE=homestead", "DB_DATABASE={$database}", file_get_contents($path))
+        );
     }
 }


### PR DESCRIPTION
This PR replaces the previous PR (https://github.com/laravel/installer/pull/83). As suggested I've updated the script the use `str_replace` instead of `sed`. Here's the description of the original PR:

> This PR updates the DB_DATABASE value in .env and .env.example to the given name of the app. This is one of the first things I do when I create a new Laravel project and I thought it would be great if the installer did it for me. I think most developers have more than one project installed locally, so homestead will almost always be replaced.