### PR TITLE
merge Lumen installer and Laravel installer

### DIFF
--- a/laravel
+++ b/laravel
@@ -8,6 +8,7 @@ if (file_exists(__DIR__.'/../../autoload.php')) {
 }
 
 $app = new Symfony\Component\Console\Application('Laravel Installer', '2.0.1');
-$app->add(new Laravel\Installer\Console\NewCommand);
+$app->add(new Laravel\Installer\Console\NewLaravelCommand);
+$app->add(new Laravel\Installer\Console\NewLumenCommand);
 
 $app->run();

--- a/src/NewLaravelCommand.php
+++ b/src/NewLaravelCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 
-class NewCommand extends Command
+class NewLaravelCommand extends Command
 {
     /**
      * Configure the command options.
@@ -24,8 +24,9 @@ class NewCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('new')
-            ->setDescription('Create a new Laravel application')
+            ->setName('new:laravel')
+            ->setAliases(['new'])
+            ->setDescription('Create a new Laravel application.')
             ->addArgument('name', InputArgument::OPTIONAL)
             ->addOption('dev', null, InputOption::VALUE_NONE, 'Installs the latest "development" release')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Forces install even if the directory already exists');

--- a/src/NewLumenCommand.php
+++ b/src/NewLumenCommand.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Laravel\Installer\Console;
+
+use ZipArchive;
+use RuntimeException;
+use GuzzleHttp\Client;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class NewLumenCommand extends Command
+{
+    /**
+     * Configure the command options.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('new:lumen')
+            ->setDescription('Create a new Lumen application.')
+            ->addArgument('name', InputArgument::REQUIRED);
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @param  InputInterface  $input
+     * @param  OutputInterface  $output
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if (! class_exists('ZipArchive')) {
+            throw new RuntimeException('The Zip PHP extension is not installed. Please install it and try again.');
+        }
+
+        $this->verifyApplicationDoesntExist(
+            $directory = getcwd().'/'.$input->getArgument('name')
+        );
+
+        $output->writeln('<info>Crafting application...</info>');
+
+        $this->download($zipFile = $this->makeFilename())
+             ->extract($zipFile, $directory)
+             ->cleanUp($zipFile);
+
+        $composer = $this->findComposer();
+
+        $commands = [
+            $composer.' install --no-scripts',
+        ];
+
+        if ($input->getOption('no-ansi')) {
+            $commands = array_map(function ($value) {
+                return $value.' --no-ansi';
+            }, $commands);
+        }
+
+        $process = new Process(implode(' && ', $commands), $directory, null, null, null);
+
+        if ('\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {
+            $process->setTty(true);
+        }
+
+        $process->run(function ($type, $line) use ($output) {
+            $output->write($line);
+        });
+
+        $output->writeln('<comment>Application ready! Build something amazing.</comment>');
+    }
+
+    /**
+     * Verify that the application does not already exist.
+     *
+     * @param  string  $directory
+     * @return void
+     */
+    protected function verifyApplicationDoesntExist($directory)
+    {
+        if (is_dir($directory)) {
+            throw new RuntimeException('Application already exists!');
+        }
+    }
+
+    /**
+     * Generate a random temporary filename.
+     *
+     * @return string
+     */
+    protected function makeFilename()
+    {
+        return getcwd().'/lumen_'.md5(time().uniqid()).'.zip';
+    }
+
+    /**
+     * Download the temporary Zip to the given file.
+     *
+     * @param  string  $zipFile
+     * @return $this
+     */
+    protected function download($zipFile)
+    {
+        $response = (new Client)->get('http://cabinet.laravel.com/latest_lumen.zip');
+
+        file_put_contents($zipFile, $response->getBody());
+
+        return $this;
+    }
+
+    /**
+     * Extract the zip file into the given directory.
+     *
+     * @param  string  $zipFile
+     * @param  string  $directory
+     * @return $this
+     */
+    protected function extract($zipFile, $directory)
+    {
+        $archive = new ZipArchive;
+
+        $archive->open($zipFile);
+
+        $archive->extractTo($directory);
+
+        $archive->close();
+
+        return $this;
+    }
+
+    /**
+     * Clean-up the Zip file.
+     *
+     * @param  string  $zipFile
+     * @return $this
+     */
+    protected function cleanUp($zipFile)
+    {
+        @chmod($zipFile, 0777);
+
+        @unlink($zipFile);
+
+        return $this;
+    }
+
+    /**
+     * Get the composer command for the environment.
+     *
+     * @return string
+     */
+    protected function findComposer()
+    {
+        if (file_exists(getcwd().'/composer.phar')) {
+            return '"'.PHP_BINARY.'" composer.phar';
+        }
+
+        return 'composer';
+    }
+}


### PR DESCRIPTION
The Laravel and Lumen installer packages have about 99% of their code shared. This PR merges them, with the intention that we deprecate and drop support for the Lumen installer repo.

Installing a Laravel application will remain the same:

```sh
laravel new MyApp
```

Lumen installation will change slightly. Instead of:

```sh
lumen new MyApp
```

it will become:

```sh
laravel new:lumen MyApp
```

Merging these 2 packages will make sure they are both getting maintained and updated, and will reduce the maintenance load by dropping the Lumen repo.

There is probably the ability to abstract a parent class out of these 2 commands now, but I wanted to start with this and see if you guys are on board.

We could also tweak the naming if you think `laravel new:lumen MyApp` is too verbose. One option would be `laravel lumen MyApp`