### PR TITLE
Idea to allow preset package installs using a JSON file at the user root

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -29,7 +29,7 @@ class NewCommand extends Command
             ->addArgument('name', InputArgument::OPTIONAL)
             ->addOption('dev', null, InputOption::VALUE_NONE, 'Installs the latest "development" release')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Forces install even if the directory already exists')
-            ->addOption('preset', null, InputOption::VALUE_REQUIRED, 'Choose a preset list of packages to install along with your new Laravel installtion');
+            ->addOption('preset', null, InputOption::VALUE_REQUIRED, 'Choose a preset list of packages to install along with your new Laravel installation');
     }
 
     /**


### PR DESCRIPTION
This pull request begins the ability to allow users to specify a `laravel-installer.json` file in their home directory to facilitate quickly pulling in extra packages when spinning up a new project.

The following format, using the format `prefix => require` is suggested:

```json
{
    "media": {
        "spatie/laravel-medialibrary": "^7.0.0"
    }
}
```

When creating a new install using `laravel new`, you can use the `--preset` option to include the extra packages: `laravel new --preset=media`.

This would:
1) Allows users to quickly (and portably) create distributions that include packages they use frequently.
2) Allow them to share this between a team or other framework users using a single simple file or JSON snippet.
3) Save time when spinning up new projects.

Currently doesn't do `dev` dependencies, but we can add that in as part of the JSON configuration if needs be.

Just preliminary thoughts - i'd definitely use this tool myself, so looking for ideas and feedback.

Thanks.

