### PR TITLE
Verify directory is also empty

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -92,6 +92,17 @@ class NewCommand extends Command
     }
 
     /**
+     * Check that the directory is empty.
+     *
+     * @param  string  $directory
+     * @return bool
+     */
+    protected function checkDirectoryIsEmpty($directory)
+    {
+        return count(array_diff(scandir($directory), ['..', '.'])) === 0;
+    }
+
+    /**
      * Verify that the application does not already exist.
      *
      * @param  string  $directory
@@ -99,7 +110,7 @@ class NewCommand extends Command
      */
     protected function verifyApplicationDoesntExist($directory)
     {
-        if ((is_dir($directory) || is_file($directory)) && $directory != getcwd()) {
+        if ((is_dir($directory) && ! $this->checkDirectoryIsEmpty($directory)) || is_file($directory)) {
             throw new RuntimeException('Application already exists!');
         }
     }


### PR DESCRIPTION
Running `laravel new` without specifying a directory will install the framework in the current working directory.

### What this change does:

Checks if the directory is empty before proceeding which i imagine 99% of the time is what you want.

### Benefits

* Prevent you from polluting another directory you didn't mean to as it already contains files.
* Prevents you from overriding an existing laravel application in the CWD.

Yes, version control is a wonderful thing for the second point, but no help if you haven't already initialised a repo ie. testing a quick concept
