### PR TITLE
[Feature] Add --auth option to 'new' command

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -28,7 +28,8 @@ class NewCommand extends Command
             ->setDescription('Create a new Laravel application')
             ->addArgument('name', InputArgument::OPTIONAL)
             ->addOption('dev', null, InputOption::VALUE_NONE, 'Installs the latest "development" release')
-            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Forces install even if the directory already exists');
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Forces install even if the directory already exists')
+            ->addOption('auth', 'a', InputOption::VALUE_NONE, 'Install the laravel/ui package and bootstrap authentication');
     }
 
     /**
@@ -76,6 +77,11 @@ class NewCommand extends Command
             $commands = array_map(function ($value) {
                 return $value.' --quiet';
             }, $commands);
+        }
+
+        if ($input->getOption('auth')) {
+            $commands[] = $composer.' require laravel/ui';
+            $commands[] = 'php artisan ui:auth';
         }
 
         $process = new Process(implode(' && ', $commands), $directory, null, null, null);


### PR DESCRIPTION
## Problem
Although there is no actual problem here, this feature was request on the laravel/ideas issue board (https://github.com/laravel/ideas/issues/1833). 

I think this is actually a nice and clean addition to the installer, proving how easy it is to get a full authentication system running in Laravel.

## Solution
I have added a new option to the command, `--auth`, which will install the laravel/ui package and run the `php artisan ui:auth` command.

As @mattstauffer mentioned on the issue, these extra steps can already be removed by using Lambo or a custom Bash alias, but including it with the installer itself is, in my opinion, cleaner and easier for the user.
