### PR TITLE
Create a new project in the current directory using "laravel new ."

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -44,7 +44,9 @@ class NewCommand extends Command
             throw new RuntimeException('The Zip PHP extension is not installed. Please install it and try again.');
         }
 
-        $directory = ($input->getArgument('name')) ? getcwd().'/'.$input->getArgument('name') : getcwd();
+        $name = $input->getArgument('name');
+
+        $directory = $name && $name !== '.' ? getcwd().'/'.$name : getcwd();
 
         if (! $input->getOption('force')) {
             $this->verifyApplicationDoesntExist($directory);


### PR DESCRIPTION
If you want to create a new laravel project in an existing directory, you have to use `laravel new` (without a path). If you try using `laravel new .`, like you would with most command line utilities, you get an error "Application already exists!".

This PR makes it possible to create a new laravel project in the current directory using `laravel new .`