### PR TITLE
Make sure zip file is valid before extracting

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -152,10 +152,10 @@ class NewCommand extends Command
     {
         $archive = new ZipArchive;
 
-        $res = $archive->open($zipFile, ZipArchive::CHECKCONS);
+        $response = $archive->open($zipFile, ZipArchive::CHECKCONS);
 
-        if ($res === ZipArchive::ER_NOZIP) {
-            throw new RuntimeException('The zip file could not download. Check that you are able to access http://cabinet.laravel.com/latest.zip');
+        if ($response === ZipArchive::ER_NOZIP) {
+            throw new RuntimeException('The zip file could not download. Verify that you are able to access: http://cabinet.laravel.com/latest.zip');
         }
 
         $archive->extractTo($directory);

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -152,7 +152,11 @@ class NewCommand extends Command
     {
         $archive = new ZipArchive;
 
-        $archive->open($zipFile);
+        $res = $archive->open($zipFile, ZipArchive::CHECKCONS);
+
+        if ($res === ZipArchive::ER_NOZIP) {
+            throw new RuntimeException('The zip file could not download. Check that you are able to access http://cabinet.laravel.com/latest.zip');
+        }
 
         $archive->extractTo($directory);
 


### PR DESCRIPTION
The `laravel new` command was consistently failing for me. My corporate firewall was scanning the ZIP before it would let the download continue, so what was immediately returned was not a ZIP. The extract was failing because of that.

Someone else on StackOverflow was having the same problem [here](https://stackoverflow.com/a/47392640).