### PR TITLE
[3.x] Prepare 3.0 release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,12 @@
 * text=auto
 
 /.github export-ignore
+/tests export-ignore
+/tests-output export-ignore
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .styleci.yml export-ignore
+.travis.yml export-ignore
 CHANGELOG.md export-ignore
+phpunit.xml.dist export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /vendor
 composer.lock
+phpunit.xml
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: php
+
+php:
+  - 7.2
+  - 7.3
+
+sudo: false
+
+before_install:
+  - phpenv config-rm xdebug.ini || true
+
+install: travis_retry composer install --no-interaction --prefer-dist
+
+script: vendor/bin/phpunit --verbose

--- a/bin/laravel
+++ b/bin/laravel
@@ -4,7 +4,7 @@
 if (file_exists(__DIR__.'/../../autoload.php')) {
     require __DIR__.'/../../autoload.php';
 } else {
-    require __DIR__ . '/vendor/autoload.php';
+    require __DIR__.'/vendor/autoload.php';
 }
 
 $app = new Symfony\Component\Console\Application('Laravel Installer', '2.3.0');

--- a/bin/laravel
+++ b/bin/laravel
@@ -4,7 +4,7 @@
 if (file_exists(__DIR__.'/../../autoload.php')) {
     require __DIR__.'/../../autoload.php';
 } else {
-    require __DIR__.'/vendor/autoload.php';
+    require __DIR__ . '/vendor/autoload.php';
 }
 
 $app = new Symfony\Component\Console\Application('Laravel Installer', '2.3.0');

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.x-dev"
+            "dev-master": "3.x-dev"
         }
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
         "php": "^7.2",
         "ext-zip": "*",
         "guzzlehttp/guzzle": "^6.0",
-        "symfony/console": "^3.0|^4.0",
-        "symfony/filesystem": "^3.0|^4.0",
-        "symfony/process": "^3.0|^4.0"
+        "symfony/console": "^3.0|^4.0|^5.0",
+        "symfony/filesystem": "^3.0|^4.0|^5.0",
+        "symfony/process": "^3.0|^4.0|^5.0"
     },
     "bin": [
         "bin/laravel"

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
         "php": "^7.2",
         "ext-zip": "*",
         "guzzlehttp/guzzle": "^6.0",
-        "symfony/console": "^3.0|^4.0|^5.0",
-        "symfony/filesystem": "^3.0|^4.0|^5.0",
-        "symfony/process": "^3.0|^4.0|^5.0"
+        "symfony/console": "^4.0|^5.0",
+        "symfony/filesystem": "^4.0|^5.0",
+        "symfony/process": "^4.0|^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0"

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "require": {
+        "php": "^7.2",
         "ext-zip": "*",
         "guzzlehttp/guzzle": "^6.0",
         "symfony/console": "^3.0|^4.0",

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
     },
     "require": {
         "ext-zip": "*",
-        "guzzlehttp/guzzle": "~6.0",
-        "symfony/console": "~3.0|~4.0",
-        "symfony/filesystem": "~3.0|~4.0",
-        "symfony/process": "~3.0|~4.0"
+        "guzzlehttp/guzzle": "^6.0",
+        "symfony/console": "^3.0|^4.0",
+        "symfony/filesystem": "^3.0|^4.0",
+        "symfony/process": "^3.0|^4.0"
     },
     "bin": [
         "laravel"

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,20 @@
         "symfony/filesystem": "^3.0|^4.0|^5.0",
         "symfony/process": "^3.0|^4.0|^5.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^8.0"
+    },
     "bin": [
         "bin/laravel"
     ],
     "autoload": {
         "psr-4": {
             "Laravel\\Installer\\Console\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Laravel\\Installer\\Console\\Tests\\": "tests/"
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,6 @@
             "email": "taylorotwell@gmail.com"
         }
     ],
-    "autoload": {
-        "psr-4": {
-            "Laravel\\Installer\\Console\\": "src/"
-        }
-    },
     "require": {
         "ext-zip": "*",
         "guzzlehttp/guzzle": "^6.0",
@@ -22,6 +17,21 @@
         "symfony/process": "^3.0|^4.0"
     },
     "bin": [
-        "laravel"
-    ]
+        "bin/laravel"
+    ],
+    "autoload": {
+        "psr-4": {
+            "Laravel\\Installer\\Console\\": "src/"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.x-dev"
+        }
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         verbose="true"
+>
+    <testsuites>
+        <testsuite name="Laravel Installer Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+            <exclude>./tests/scaffolds</exclude>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -81,7 +81,7 @@ class NewCommand extends Command
             }, $commands);
         }
 
-        $process = new Process(implode(' && ', $commands), $directory, null, null, null);
+        $process = Process::fromShellCommandline(implode(' && ', $commands), $directory, null, null, null);
 
         if ('\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {
             $process->setTty(true);

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -37,7 +37,7 @@ class NewCommand extends Command
      *
      * @param  \Symfony\Component\Console\Input\InputInterface  $input
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
-     * @return void
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -94,6 +94,8 @@ class NewCommand extends Command
         if ($process->isSuccessful()) {
             $output->writeln('<comment>Application ready! Build something amazing.</comment>');
         }
+
+        return 0;
     }
 
     /**

--- a/tests-output/.gitignore
+++ b/tests-output/.gitignore
@@ -1,2 +1,2 @@
-my-app
+*
 !.gitignore

--- a/tests-output/.gitignore
+++ b/tests-output/.gitignore
@@ -1,0 +1,2 @@
+my-app
+!.gitignore

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Laravel\Installer\Console\Tests;
+
+use Laravel\Installer\Console\NewCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+class NewCommandTest extends TestCase
+{
+    public function test_it_can_scaffold_a_new_laravel_app()
+    {
+        $scaffoldDirectoryName = 'tests-output/my-app';
+        $scaffoldDirectory = __DIR__.'/../'.$scaffoldDirectoryName;
+
+        if (file_exists($scaffoldDirectory)) {
+            (new Filesystem)->remove($scaffoldDirectory);
+        }
+
+        $app = new Application('Laravel Installer');
+        $app->add(new NewCommand);
+
+        $tester = new CommandTester($app->find('new'));
+
+        $statusCode = $tester->execute(['name' => $scaffoldDirectoryName, '--auth' => null]);
+
+        $this->assertEquals($statusCode, 0);
+        $this->assertDirectoryExists($scaffoldDirectory.'/vendor');
+        $this->assertFileExists($scaffoldDirectory.'/.env');
+        $this->assertFileExists($scaffoldDirectory.'/resources/views/auth/login.blade.php');
+    }
+}


### PR DESCRIPTION
This PR updates the installer with a couple of things:

- Provides Symfony 5.x support
- Drops Symfony 3.x
- Minimum PHP version is now 7.2 as the framework (since you can't use the installer on anything lower anyway)
- Added an integration test for the command
- Added a Travis build file for testing in multiple PHP environments
- Moved the laravel binary to the more sensible default `/bin` folder just like Envoy
- Fixed a bug with improper string passing to the Process constructor

This will need to be released as a new major release.