### PR TITLE
require symfony/process 4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "guzzlehttp/guzzle": "^6.0",
         "symfony/console": "^4.0|^5.0",
         "symfony/filesystem": "^4.0|^5.0",
-        "symfony/process": "^4.0|^5.0"
+        "symfony/process": "^4.2|^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0"


### PR DESCRIPTION
`NewCommand` relies on `Process::fromShellCommandline()`, which was introduced in `symfony/process` version [4.2.0](https://github.com/symfony/process/commit/d6f417d21efe2a2b91c0c8a19d938c5db18d81d3).