### PR TITLE
Add Laravel packages on creating a new project

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -297,13 +297,13 @@ class NewCommand extends Command
         $composerPackages = '';
         foreach ($laravelPackages as $laravelPackage) {
             if ($dev) {
-                if (isset(self::LARAVEL_DEV_PACKAGES[$laravelPackage]) ) {
+                if (isset(self::LARAVEL_DEV_PACKAGES[$laravelPackage])) {
                     $composerPackages .= ' '.self::LARAVEL_DEV_PACKAGES[$laravelPackage];
                 }
                 continue;
             }
 
-            if (isset(self::LARAVEL_PACKAGES[$laravelPackage]) ) {
+            if (isset(self::LARAVEL_PACKAGES[$laravelPackage])) {
                 $composerPackages .= ' '.self::LARAVEL_PACKAGES[$laravelPackage];
             }
         }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -39,7 +39,6 @@ class NewCommand extends Command
         'dusk' => 'dusk:install',
         'scout' => 'vendor:publish --provider="Laravel\Scout\ScoutServiceProvider"',
     ];
-    
     /**
      * Configure the command options.
      *

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -330,7 +330,7 @@ class NewCommand extends Command
         $packagesInstallCommands = '';
 
         foreach ($laravelPackages as $laravelPackage) {
-            if (array_key_exists($laravelPackage, self::LARAVEL_PACKAGES_INSTALL_COMMAND)) {
+            if (isset(self::LARAVEL_PACKAGES_INSTALL_COMMAND[$laravelPackage])) {
                 if ($packagesInstallCommands !== '') {
                     $packagesInstallCommands .= ' && ';
                 }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -24,12 +24,12 @@ class NewCommand extends Command
         'passport' => 'laravel/passport',
         'scout' => 'laravel/scout',
         'nexmo' => 'laravel/nexmo-notification-channel',
-        'slack' => 'laravel/slack-notification-channel'
+        'slack' => 'laravel/slack-notification-channel',
     ];
 
     protected const LARAVEL_DEV_PACKAGES = [
         'ui' => 'laravel/ui',
-        'dusk' => 'laravel/dusk'
+        'dusk' => 'laravel/dusk',
     ];
 
     protected const LARAVEL_PACKAGES_INSTALL_COMMAND = [
@@ -297,12 +297,12 @@ class NewCommand extends Command
         $composerPackages = '';
         foreach ($laravelPackages as $laravelPackage) {
             if (array_key_exists($laravelPackage, self::LARAVEL_PACKAGES)) {
-                $composerPackages .= ' ' . self::LARAVEL_PACKAGES[$laravelPackage];
+                $composerPackages .= ' '.self::LARAVEL_PACKAGES[$laravelPackage];
             }
         }
 
         if ($composerPackages !== '') {
-            return $composer . ' require' . $composerPackages;
+            return $composer.' require'.$composerPackages;
         }
 
         return $composerPackages;
@@ -320,12 +320,12 @@ class NewCommand extends Command
         $composerPackages = '';
         foreach ($laravelPackages as $laravelPackage) {
             if (array_key_exists($laravelPackage, self::LARAVEL_DEV_PACKAGES)) {
-                $composerPackages .= ' ' . self::LARAVEL_DEV_PACKAGES[$laravelPackage];
+                $composerPackages .= ' '.self::LARAVEL_DEV_PACKAGES[$laravelPackage];
             }
         }
 
         if ($composerPackages !== '') {
-            return $composer . ' require --dev' . $composerPackages;
+            return $composer.' require --dev'.$composerPackages;
         }
 
         return $composerPackages;
@@ -347,7 +347,7 @@ class NewCommand extends Command
                     $packagesInstallCommands .= ' && ';
                 }
 
-                $packagesInstallCommands .= 'php artisan ' . self::LARAVEL_PACKAGES_INSTALL_COMMAND[$laravelPackage];
+                $packagesInstallCommands .= 'php artisan '.self::LARAVEL_PACKAGES_INSTALL_COMMAND[$laravelPackage];
             }
         }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -312,6 +312,7 @@ class NewCommand extends Command
             if ($dev) {
                 return $composer.' require --dev'.$composerPackages;
             }
+            
             return $composer.' require'.$composerPackages;
         }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -312,7 +312,7 @@ class NewCommand extends Command
             if ($dev) {
                 return $composer.' require --dev'.$composerPackages;
             }
-            
+
             return $composer.' require'.$composerPackages;
         }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -290,7 +290,7 @@ class NewCommand extends Command
      * @param  string  $composer
      * @return string
      */
-    private function getLaravelPackages(string $packages, string $composer)
+    private function getLaravelPackages($packages, $composer)
     {
         $laravelPackages = explode(',', $packages);
 
@@ -313,7 +313,7 @@ class NewCommand extends Command
      * @param  string  $composer
      * @return  string
      */
-    private function getLaravelDevPackages(string $packages, string $composer)
+    private function getLaravelDevPackages($packages, $composer)
     {
         $laravelPackages = explode(',', $packages);
 
@@ -335,7 +335,7 @@ class NewCommand extends Command
      * @param  string  $packages
      * @return  string
      */
-    private function getLaravelInstallCommands(string $packages)
+    private function getLaravelInstallCommands($packages)
     {
         $laravelPackages = explode(',', $packages);
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -16,7 +16,7 @@ use ZipArchive;
 
 class NewCommand extends Command
 {
-    public const LARAVEL_PACKAGES = [
+    protected const LARAVEL_PACKAGES = [
         'telescope' => 'laravel/telescope',
         'socialite' => 'laravel/socialite',
         'horizon' => 'laravel/horizon',
@@ -27,12 +27,12 @@ class NewCommand extends Command
         'slack' => 'laravel/slack-notification-channel'
     ];
 
-    public const LARAVEL_DEV_PACKAGES = [
+    protected const LARAVEL_DEV_PACKAGES = [
         'ui' => 'laravel/ui',
         'dusk' => 'laravel/dusk'
     ];
 
-    public const LARAVEL_PACKAGES_INSTALL_COMMAND = [
+    protected const LARAVEL_PACKAGES_INSTALL_COMMAND = [
         'telescope' => 'telescope:install',
         'horizon' => 'horizon:install',
         'passport' => 'passport:install',

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -286,8 +286,8 @@ class NewCommand extends Command
     }
 
     /**
-     * @param string $packages
-     * @param string $composer
+     * @param  string  $packages
+     * @param  string  $composer
      * @return string
      */
     private function getLaravelPackages(string $packages, string $composer)
@@ -309,9 +309,9 @@ class NewCommand extends Command
     }
 
     /**
-     * @param string $packages
-     * @param string $composer
-     * @return string
+     * @param  string  $packages
+     * @param  string  $composer
+     * @return  string
      */
     private function getLaravelDevPackages(string $packages, string $composer)
     {
@@ -332,8 +332,8 @@ class NewCommand extends Command
     }
 
     /**
-     * @param string $packages
-     * @return string
+     * @param  string  $packages
+     * @return  string
      */
     private function getLaravelInstallCommands(string $packages)
     {

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -39,6 +39,7 @@ class NewCommand extends Command
         'dusk' => 'dusk:install',
         'scout' => 'vendor:publish --provider="Laravel\Scout\ScoutServiceProvider"',
     ];
+    
     /**
      * Configure the command options.
      *

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -288,7 +288,7 @@ class NewCommand extends Command
     /**
      * @param  string  $packages
      * @param  string  $composer
-     * @return string
+     * @return  string
      */
     private function getLaravelPackages($packages, $composer)
     {

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -39,6 +39,7 @@ class NewCommand extends Command
         'dusk' => 'dusk:install',
         'scout' => 'vendor:publish --provider="Laravel\Scout\ScoutServiceProvider"',
     ];
+
     /**
      * Configure the command options.
      *

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -39,8 +39,7 @@ class NewCommand extends Command
         'dusk' => 'dusk:install',
         'scout' => 'vendor:publish --provider="Laravel\Scout\ScoutServiceProvider"',
     ];
-
-
+    
     /**
      * Configure the command options.
      *

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -2,17 +2,17 @@
 
 namespace Laravel\Installer\Console;
 
-use ZipArchive;
-use RuntimeException;
 use GuzzleHttp\Client;
-use Symfony\Component\Process\Process;
-use Symfony\Component\Filesystem\Filesystem;
+use RuntimeException;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
+use ZipArchive;
 
 class NewCommand extends Command
 {
@@ -61,49 +61,49 @@ class NewCommand extends Command
     /**
      * Execute the command.
      *
-     * @param \Symfony\Component\Console\Input\InputInterface $input
-     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (!extension_loaded('zip')) {
+        if (! extension_loaded('zip')) {
             throw new RuntimeException('The Zip PHP extension is not installed. Please install it and try again.');
         }
 
         $name = $input->getArgument('name');
 
-        $directory = $name && $name !== '.' ? getcwd() . '/' . $name : getcwd();
+        $directory = $name && $name !== '.' ? getcwd().'/'.$name : getcwd();
 
-        if (!$input->getOption('force')) {
+        if (! $input->getOption('force')) {
             $this->verifyApplicationDoesntExist($directory);
         }
 
         $output->writeln('<info>Crafting application...</info>');
 
         $this->download($zipFile = $this->makeFilename(), $this->getVersion($input))
-            ->extract($zipFile, $directory)
-            ->prepareWritableDirectories($directory, $output)
-            ->cleanUp($zipFile);
+             ->extract($zipFile, $directory)
+             ->prepareWritableDirectories($directory, $output)
+             ->cleanUp($zipFile);
 
         $composer = $this->findComposer();
 
         $commands = [
-            $composer . ' install --no-scripts',
-            $composer . ' run-script post-root-package-install',
-            $composer . ' run-script post-create-project-cmd',
-            $composer . ' run-script post-autoload-dump',
+            $composer.' install --no-scripts',
+            $composer.' run-script post-root-package-install',
+            $composer.' run-script post-create-project-cmd',
+            $composer.' run-script post-autoload-dump',
         ];
 
         if ($input->getOption('no-ansi')) {
             $commands = array_map(function ($value) {
-                return $value . ' --no-ansi';
+                return $value.' --no-ansi';
             }, $commands);
         }
 
         if ($input->getOption('quiet')) {
             $commands = array_map(function ($value) {
-                return $value . ' --quiet';
+                return $value.' --quiet';
             }, $commands);
         }
 
@@ -131,7 +131,7 @@ class NewCommand extends Command
         $process->run(function ($type, $line) use ($output) {
             $output->write($line);
         });
-        
+
         if ($process->isSuccessful()) {
             $output->writeln('<comment>Application ready! Build something amazing.</comment>');
         }
@@ -142,7 +142,7 @@ class NewCommand extends Command
     /**
      * Verify that the application does not already exist.
      *
-     * @param string $directory
+     * @param  string  $directory
      * @return void
      */
     protected function verifyApplicationDoesntExist($directory)
@@ -159,14 +159,14 @@ class NewCommand extends Command
      */
     protected function makeFilename()
     {
-        return getcwd() . '/laravel_' . md5(time() . uniqid()) . '.zip';
+        return getcwd().'/laravel_'.md5(time().uniqid()).'.zip';
     }
 
     /**
      * Download the temporary Zip to the given file.
      *
-     * @param string $zipFile
-     * @param string $version
+     * @param  string  $zipFile
+     * @param  string  $version
      * @return $this
      */
     protected function download($zipFile, $version = 'master')
@@ -183,7 +183,7 @@ class NewCommand extends Command
                 break;
         }
 
-        $response = (new Client)->get('http://cabinet.laravel.com/' . $filename);
+        $response = (new Client)->get('http://cabinet.laravel.com/'.$filename);
 
         file_put_contents($zipFile, $response->getBody());
 
@@ -193,8 +193,8 @@ class NewCommand extends Command
     /**
      * Extract the Zip file into the given directory.
      *
-     * @param string $zipFile
-     * @param string $directory
+     * @param  string  $zipFile
+     * @param  string  $directory
      * @return $this
      */
     protected function extract($zipFile, $directory)
@@ -217,7 +217,7 @@ class NewCommand extends Command
     /**
      * Clean-up the Zip file.
      *
-     * @param string $zipFile
+     * @param  string  $zipFile
      * @return $this
      */
     protected function cleanUp($zipFile)
@@ -232,8 +232,8 @@ class NewCommand extends Command
     /**
      * Make sure the storage and bootstrap cache directories are writable.
      *
-     * @param string $appDirectory
-     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param  string  $appDirectory
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @return $this
      */
     protected function prepareWritableDirectories($appDirectory, OutputInterface $output)
@@ -241,8 +241,8 @@ class NewCommand extends Command
         $filesystem = new Filesystem;
 
         try {
-            $filesystem->chmod($appDirectory . DIRECTORY_SEPARATOR . 'bootstrap/cache', 0755, 0000, true);
-            $filesystem->chmod($appDirectory . DIRECTORY_SEPARATOR . 'storage', 0755, 0000, true);
+            $filesystem->chmod($appDirectory.DIRECTORY_SEPARATOR.'bootstrap/cache', 0755, 0000, true);
+            $filesystem->chmod($appDirectory.DIRECTORY_SEPARATOR.'storage', 0755, 0000, true);
         } catch (IOExceptionInterface $e) {
             $output->writeln('<comment>You should verify that the "storage" and "bootstrap/cache" directories are writable.</comment>');
         }
@@ -253,7 +253,7 @@ class NewCommand extends Command
     /**
      * Get the version that should be downloaded.
      *
-     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
      * @return string
      */
     protected function getVersion(InputInterface $input)
@@ -276,10 +276,10 @@ class NewCommand extends Command
      */
     protected function findComposer()
     {
-        $composerPath = getcwd() . '/composer.phar';
+        $composerPath = getcwd().'/composer.phar';
 
         if (file_exists($composerPath)) {
-            return '"' . PHP_BINARY . '" ' . $composerPath;
+            return '"'.PHP_BINARY.'" '.$composerPath;
         }
 
         return 'composer';

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -131,8 +131,7 @@ class NewCommand extends Command
         $process->run(function ($type, $line) use ($output) {
             $output->write($line);
         });
-
-
+        
         if ($process->isSuccessful()) {
             $output->writeln('<comment>Application ready! Build something amazing.</comment>');
         }

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -35,7 +35,7 @@ class NewCommandTest extends TestCase
     public function test_it_can_scaffold_a_new_laravel_app_with_packages()
     {
         $scaffoldDirectoryName = 'tests-output/my-app';
-        $scaffoldDirectory = __DIR__ . '/../' . $scaffoldDirectoryName;
+        $scaffoldDirectory = __DIR__.'/../'.$scaffoldDirectoryName;
 
         if (file_exists($scaffoldDirectory)) {
             (new Filesystem)->remove($scaffoldDirectory);
@@ -49,7 +49,7 @@ class NewCommandTest extends TestCase
         $statusCode = $tester->execute(['name' => $scaffoldDirectoryName, '--auth' => null, '--with' => 'telescope,horizon']);
 
         $this->assertEquals($statusCode, 0);
-        $this->assertFileExists($scaffoldDirectory . '/config/telescope.php');
-        $this->assertFileExists($scaffoldDirectory . '/config/horizon.php');
+        $this->assertFileExists($scaffoldDirectory.'/config/telescope.php');
+        $this->assertFileExists($scaffoldDirectory.'/config/horizon.php');
     }
 }

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -2,11 +2,11 @@
 
 namespace Laravel\Installer\Console\Tests;
 
-use Laravel\Installer\Console\NewCommand;
 use PHPUnit\Framework\TestCase;
+use Laravel\Installer\Console\NewCommand;
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Console\Tester\CommandTester;
 
 class NewCommandTest extends TestCase
 {

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -13,7 +13,7 @@ class NewCommandTest extends TestCase
     public function test_it_can_scaffold_a_new_laravel_app()
     {
         $scaffoldDirectoryName = 'tests-output/my-app';
-        $scaffoldDirectory = __DIR__.'/../'.$scaffoldDirectoryName;
+        $scaffoldDirectory = __DIR__ . '/../' . $scaffoldDirectoryName;
 
         if (file_exists($scaffoldDirectory)) {
             (new Filesystem)->remove($scaffoldDirectory);
@@ -27,8 +27,29 @@ class NewCommandTest extends TestCase
         $statusCode = $tester->execute(['name' => $scaffoldDirectoryName, '--auth' => null]);
 
         $this->assertEquals($statusCode, 0);
-        $this->assertDirectoryExists($scaffoldDirectory.'/vendor');
-        $this->assertFileExists($scaffoldDirectory.'/.env');
-        $this->assertFileExists($scaffoldDirectory.'/resources/views/auth/login.blade.php');
+        $this->assertDirectoryExists($scaffoldDirectory . '/vendor');
+        $this->assertFileExists($scaffoldDirectory . '/.env');
+        $this->assertFileExists($scaffoldDirectory . '/resources/views/auth/login.blade.php');
+    }
+
+    public function test_it_can_scaffold_a_new_laravel_app_with_packages()
+    {
+        $scaffoldDirectoryName = 'tests-output/my-app';
+        $scaffoldDirectory = __DIR__ . '/../' . $scaffoldDirectoryName;
+
+        if (file_exists($scaffoldDirectory)) {
+            (new Filesystem)->remove($scaffoldDirectory);
+        }
+
+        $app = new Application('Laravel Installer');
+        $app->add(new NewCommand);
+
+        $tester = new CommandTester($app->find('new'));
+
+        $statusCode = $tester->execute(['name' => $scaffoldDirectoryName, '--auth' => null, '--with' => 'telescope,horizon']);
+
+        $this->assertEquals($statusCode, 0);
+        $this->assertFileExists($scaffoldDirectory . '/config/telescope.php');
+        $this->assertFileExists($scaffoldDirectory . '/config/horizon.php');
     }
 }

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -2,18 +2,18 @@
 
 namespace Laravel\Installer\Console\Tests;
 
-use PHPUnit\Framework\TestCase;
 use Laravel\Installer\Console\NewCommand;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
 
 class NewCommandTest extends TestCase
 {
     public function test_it_can_scaffold_a_new_laravel_app()
     {
         $scaffoldDirectoryName = 'tests-output/my-app';
-        $scaffoldDirectory = __DIR__ . '/../' . $scaffoldDirectoryName;
+        $scaffoldDirectory = __DIR__.'/../'.$scaffoldDirectoryName;
 
         if (file_exists($scaffoldDirectory)) {
             (new Filesystem)->remove($scaffoldDirectory);
@@ -27,9 +27,9 @@ class NewCommandTest extends TestCase
         $statusCode = $tester->execute(['name' => $scaffoldDirectoryName, '--auth' => null]);
 
         $this->assertEquals($statusCode, 0);
-        $this->assertDirectoryExists($scaffoldDirectory . '/vendor');
-        $this->assertFileExists($scaffoldDirectory . '/.env');
-        $this->assertFileExists($scaffoldDirectory . '/resources/views/auth/login.blade.php');
+        $this->assertDirectoryExists($scaffoldDirectory.'/vendor');
+        $this->assertFileExists($scaffoldDirectory.'/.env');
+        $this->assertFileExists($scaffoldDirectory.'/resources/views/auth/login.blade.php');
     }
 
     public function test_it_can_scaffold_a_new_laravel_app_with_packages()


### PR DESCRIPTION
Hi,

This PR references to idea [#1987](https://github.com/laravel/ideas/issues/1987)

This PR add an option to laravel/installer new command that install Laravel's packages after project creation. 
Only Laravel Packages are allowed, excluding paid projects.

The option name is `with` but could be other.

An example:
`$ laravel new blog --with=ui,horizon,telescope,socialite`

This will install `ui`, `telescope` and `socialite` packages and run their `install` commands like: `php artisan telescope:install`.

The package `ui` will be installed in `require-dev` section of composer.json respecting the official documentation.


Also, I improved some code style on NewCommand Class.