### PR TITLE
Add a docs command to the CLI tool

### DIFF
--- a/src/DocsCommand.php
+++ b/src/DocsCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Laravel\Installer\Console;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
+
+class DocsCommand extends Command
+{
+    /**
+     * Configure the command options.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('docs')
+            ->setDescription('Open the Laravel docs')
+            ->addArgument('version', InputArgument::OPTIONAL);
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $uri = 'https://laravel.com/docs/';
+
+        if ($version = $input->getArgument('version')) {
+            switch ($version) {
+                case '4':
+                    $uri .= '4.2';
+                    break;
+
+                case '5':
+                    $uri .= '5.8';
+                    break;
+
+                case '6':
+                    $uri .= '6.x';
+                    break;
+
+                case '7':
+                    $uri .= '7.x';
+                    break;
+
+                default:
+                    $uri .= $version;
+                    break;
+            }
+        }
+
+        $output->writeln('<info>Opening Laravel Docs: ' . $uri . '</info>');
+
+        $process = Process::fromShellCommandline('open ' . $uri);
+        $process->run();
+
+        return 0;
+    }
+}

--- a/tests/DocsCommandTest.php
+++ b/tests/DocsCommandTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Laravel\Installer\Console\Tests;
+
+use Laravel\Installer\Console\DocsCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DocsCommandTest extends TestCase
+{
+    public function test_it_can_open_laravel_docs()
+    {
+        $app = new Application('Laravel Installer');
+        $app->add(new DocsCommand);
+
+        $tester = new CommandTester($app->find('docs'));
+
+        $statusCode = $tester->execute(['version' => 6]);
+
+        $this->assertEquals($statusCode, 0);
+        $this->assertStringContainsString('https://laravel.com/docs/6.x', $tester->getDisplay());
+    }
+}


### PR DESCRIPTION
I'v created this PR to allow any user who has the laravel installer globally installed to be able to run a command such as `laravel docs 5.2` to quickly get to the docs for a given Laravel version.

Perhaps something similar could be introduced in the Laravel core, to be able to run something like `php artisan docs` which would open the docs for a given project. 

I feel like this will be a very useful addition to the laravel installer because most developers will have this package globally installed with composer, and I think many developers still maintain legacy sites for various reasons. It becomes a bit tedious navigating to the docs website and then finding the specific version etc.

I have tried to add valid tests but happy to take feedback on improving them.

Thanks! 😄 