### PR TITLE
Using the assertSame and fix assertSame parameters

### DIFF
--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -23,7 +23,7 @@ class NewCommandTest extends TestCase
 
         $statusCode = $tester->execute(['name' => $scaffoldDirectoryName]);
 
-        $this->assertEquals($statusCode, 0);
+        $this->assertSame(0, $statusCode);
         $this->assertDirectoryExists($scaffoldDirectory.'/vendor');
         $this->assertFileExists($scaffoldDirectory.'/.env');
     }


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` and it can make assertion equals strict.
- According to the official [PHPUnit doc](https://phpunit.readthedocs.io/en/9.0/assertions.html#assertsame), the `assertSame` parameters are `assertSame(mixed $expected, mixed $actual[, string $message = ''])`.
And parameters should be switched.