### PR TITLE
[4.x] The Laravel Installer requires PHP-7.3 at least

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.9",
+        "php": "^7.3",
         "symfony/console": "^4.0|^5.0",
         "symfony/process": "^4.2|^5.0"
     },

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -69,10 +69,6 @@ class NewCommand extends Command
 
         sleep(1);
 
-        if (version_compare(PHP_VERSION, '7.3.0', '<')) {
-            throw new RuntimeException('The Laravel installer requires PHP 7.3.0 or greater. Please use "composer create-project laravel/laravel" instead.');
-        }
-
         $name = $input->getArgument('name');
 
         $directory = $name && $name !== '.' ? getcwd().'/'.$name : '.';


### PR DESCRIPTION
# Changed log

- According to this [line](https://github.com/laravel/installer/blob/master/src/NewCommand.php#L72) of `src/NewCommand` class and the [line](https://github.com/laravel/installer/blob/master/.github/workflows/tests.yml#L16) of `.github/workflows/tests.yml` file,  it should let this installer require `php-7.3` version at least on `composer.json` file.