### PR TITLE
Provide stack question default

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -51,7 +51,7 @@ class NewCommand extends Command
             $question = new ChoiceQuestion('Which Jetstream stack do you prefer?', [
                 'livewire',
                 'inertia',
-            ]);
+            ], 'livewire');
 
             $output->write(PHP_EOL);
 


### PR DESCRIPTION
Fixes the `--jet` option when run in non-interactive mode.

Fixes https://github.com/laravel/installer/issues/144