### PR TITLE
Fix for directories with spaces in current working directory path

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -84,15 +84,15 @@ class NewCommand extends Command
             if (PHP_OS_FAMILY == 'Windows') {
                 array_unshift($commands, "rd /s /q \"$directory\"");
             } else {
-                array_unshift($commands, "rm -rf $directory");
+                array_unshift($commands, "rm -rf \"$directory\"");
             }
         }
 
         if (PHP_OS_FAMILY != 'Windows') {
-            $commands[] = "chmod 644 $directory/artisan";
+            $commands[] = "chmod 644 \"$directory/artisan\"";
         }
 
-        if ($this->runCommands($commands, $input, $output)->isSuccessful()) {
+        if (($process = $this->runCommands($commands, $input, $output))->isSuccessful()) {
             if ($name && $name !== '.') {
                 $this->replaceInFile(
                     'APP_URL=http://localhost',
@@ -114,7 +114,7 @@ class NewCommand extends Command
             $output->writeln(PHP_EOL.'<comment>Application ready! Build something amazing.</comment>');
         }
 
-        return 0;
+        return $process->getExitCode();
     }
 
     /**

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -18,7 +18,7 @@ class NewCommandTest extends TestCase
             if (PHP_OS_FAMILY == 'Windows') {
                 exec("rd /s /q \"$scaffoldDirectory\"");
             } else {
-                exec("rm -rf $scaffoldDirectory");
+                exec("rm -rf \"$scaffoldDirectory\"");
             }
         }
 


### PR DESCRIPTION
Had a fresh install blow up today 😅 This PR:

- Wraps $directory passed to (non-Windows) shell commands in quotes
- Returns the process exit code so the test can catch a similar issue in the future
- Applies the same quote wrapping to the test clean up shell command