### PR TITLE
[4.x] Add warning about --force and installing in current directory

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -74,6 +74,10 @@ class NewCommand extends Command
             $this->verifyApplicationDoesntExist($directory);
         }
 
+        if ($input->getOption('force') && $directory === '.') {
+            throw new RuntimeException('Cannot use --force option when using current directory for installation!');
+        }
+
         $composer = $this->findComposer();
 
         $commands = [


### PR DESCRIPTION
Re #129 

@driesvints I ended up using the throwing an exception as [that's what the current code does](https://github.com/laravel/installer/blob/master/src/NewCommand.php#L180) if you don't use `--force` and the directory already exists as there is no `->error(...)` method as we're using the base symfony command rather than Laravels extended commands.

**--force and current directory**
![image](https://user-images.githubusercontent.com/709773/93063514-809fbb80-f6ca-11ea-979d-3f0c17c6e561.png)

**without --force and directory already exists**
![image](https://user-images.githubusercontent.com/709773/93063869-f73cb900-f6ca-11ea-91ea-cf02ebcf23cc.png)
