### PR TITLE
Ensure artisan command is executable (755)

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -93,7 +93,7 @@ class NewCommand extends Command
         }
 
         if (PHP_OS_FAMILY != 'Windows') {
-            $commands[] = "chmod 644 \"$directory/artisan\"";
+            $commands[] = "chmod 755 \"$directory/artisan\"";
         }
 
         if (($process = $this->runCommands($commands, $input, $output))->isSuccessful()) {


### PR DESCRIPTION
Alter command to `755` artisan when a new laravel application is created. I can't see a reason why not, and it would give me one less thing to do when I create new laravel applications! 😎
