### PR TITLE
Fix scaffolding in cwd

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -180,7 +180,7 @@ class NewCommand extends Command
      */
     protected function verifyApplicationDoesntExist($directory)
     {
-        if ((is_dir($directory) || is_file($directory)) && $directory != getcwd()) {
+        if ((is_dir($directory) || is_file($directory)) && realpath($directory) != getcwd()) {
             throw new RuntimeException('Application already exists!');
         }
     }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -66,7 +66,7 @@ class NewCommand extends Command
 
         $name = $input->getArgument('name');
 
-        $directory = $name && $name !== '.' ? getcwd().'/'.$name : '.';
+        $directory = $name && $name !== '.' ? getcwd().DIRECTORY_SEPARATOR.$name : '.';
 
         $version = $this->getVersion($input);
 
@@ -101,13 +101,13 @@ class NewCommand extends Command
                 $this->replaceInFile(
                     'APP_URL=http://localhost',
                     'APP_URL=http://'.$name.'.test',
-                    $directory.'/.env'
+                    $directory.DIRECTORY_SEPARATOR.'.env'
                 );
 
                 $this->replaceInFile(
                     'DB_DATABASE=laravel',
                     'DB_DATABASE='.str_replace('-', '_', strtolower($name)),
-                    $directory.'/.env'
+                    $directory.DIRECTORY_SEPARATOR.'.env'
                 );
             }
 
@@ -207,7 +207,7 @@ class NewCommand extends Command
      */
     protected function findComposer()
     {
-        $composerPath = getcwd().'/composer.phar';
+        $composerPath = getcwd().DIRECTORY_SEPARATOR.'composer.phar';
 
         if (file_exists($composerPath)) {
             return '"'.PHP_BINARY.'" '.$composerPath;

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -67,8 +67,6 @@ class NewCommandTest extends TestCase
         $app = new Application('Laravel Installer');
         $app->add(new NewCommand);
 
-        echo "Current dir: " . getcwd() . "\n";
-
         $tester = new CommandTester($app->find('new'));
 
         $statusCode = $tester->execute($parameters);

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -12,15 +12,7 @@ class NewCommandTest extends TestCase
     public function test_it_can_scaffold_a_new_laravel_app()
     {
         $scaffoldDirectoryName = 'tests-output/my-app';
-        $scaffoldDirectory = __DIR__.'/../'.$scaffoldDirectoryName;
-
-        if (file_exists($scaffoldDirectory)) {
-            if (PHP_OS_FAMILY == 'Windows') {
-                exec("rd /s /q \"$scaffoldDirectory\"");
-            } else {
-                exec("rm -rf \"$scaffoldDirectory\"");
-            }
-        }
+        $scaffoldDirectory = $this->prepareScaffoldDirectory($scaffoldDirectoryName);
 
         $app = new Application('Laravel Installer');
         $app->add(new NewCommand);
@@ -32,5 +24,41 @@ class NewCommandTest extends TestCase
         $this->assertSame(0, $statusCode);
         $this->assertDirectoryExists($scaffoldDirectory.'/vendor');
         $this->assertFileExists($scaffoldDirectory.'/.env');
+    }
+
+    public function test_it_can_scaffold_a_new_laravel_app_in_the_current_directory()
+    {
+        $scaffoldDirectoryName = 'tests-output/my-app';
+        $scaffoldDirectory = $this->prepareScaffoldDirectory($scaffoldDirectoryName);
+
+        // Create directory and change into it.
+        mkdir($scaffoldDirectory);
+        chdir($scaffoldDirectory);
+
+        $app = new Application('Laravel Installer');
+        $app->add(new NewCommand);
+
+        $tester = new CommandTester($app->find('new'));
+
+        $statusCode = $tester->execute([]);
+
+        $this->assertSame(0, $statusCode);
+        $this->assertDirectoryExists($scaffoldDirectory.'/vendor');
+        $this->assertFileExists($scaffoldDirectory.'/.env');
+    }
+
+    public function prepareScaffoldDirectory($scaffoldDirectoryName)
+    {
+        $scaffoldDirectory = __DIR__.'/../'.$scaffoldDirectoryName;
+
+        if (file_exists($scaffoldDirectory)) {
+            if (PHP_OS_FAMILY == 'Windows') {
+                exec("rd /s /q \"$scaffoldDirectory\"");
+            } else {
+                exec("rm -rf \"$scaffoldDirectory\"");
+            }
+        }
+
+        return $scaffoldDirectory;
     }
 }

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -24,11 +24,12 @@ class NewCommandTest extends TestCase
 
         // Create directory and change into it.
         if (PHP_OS_FAMILY == 'Windows') {
-            exec("mkdir \"$scaffoldDirectory\" & cd \"$scaffoldDirectory\"");
+            exec("mkdir \"$scaffoldDirectory\"");
         } else {
             mkdir($scaffoldDirectory);
-            chdir($scaffoldDirectory);
         }
+
+        chdir($scaffoldDirectory);
 
         $this->assertApplicationIsScaffolded($scaffoldDirectory, []);
     }

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -40,6 +40,10 @@ class NewCommandTest extends TestCase
     {
         $scaffoldDirectory = __DIR__.'/../'.$scaffoldDirectoryName;
 
+        if (PHP_OS_FAMILY == 'Windows') {
+            $scaffoldDirectory = preg_replace('/\//', '\\', $scaffoldDirectory);
+        }
+
         if (file_exists($scaffoldDirectory)) {
             if (PHP_OS_FAMILY == 'Windows') {
                 exec("rd /s /q \"$scaffoldDirectory\"");

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -11,7 +11,7 @@ class NewCommandTest extends TestCase
 {
     public function test_it_can_scaffold_a_new_laravel_app()
     {
-        $scaffoldDirectoryName = 'tests-output/my-app';
+        $scaffoldDirectoryName = 'tests-output'.DIRECTORY_SEPARATOR.'my-app';
         $scaffoldDirectory = $this->prepareScaffoldDirectory($scaffoldDirectoryName);
 
         $this->assertApplicationIsScaffolded($scaffoldDirectory, ['name' => $scaffoldDirectoryName]);
@@ -19,12 +19,16 @@ class NewCommandTest extends TestCase
 
     public function test_it_can_scaffold_a_new_laravel_app_in_the_current_directory()
     {
-        $scaffoldDirectoryName = 'tests-output/my-app';
+        $scaffoldDirectoryName = 'tests-output'.DIRECTORY_SEPARATOR.'my-app';
         $scaffoldDirectory = $this->prepareScaffoldDirectory($scaffoldDirectoryName);
 
         // Create directory and change into it.
-        mkdir($scaffoldDirectory);
-        chdir($scaffoldDirectory);
+        if (PHP_OS_FAMILY == 'Windows') {
+            exec("mkdir \"$scaffoldDirectory\" & cd \"$scaffoldDirectory\"");
+        } else {
+            mkdir($scaffoldDirectory);
+            chdir($scaffoldDirectory);
+        }
 
         $this->assertApplicationIsScaffolded($scaffoldDirectory, []);
     }
@@ -38,11 +42,7 @@ class NewCommandTest extends TestCase
      */
     protected function prepareScaffoldDirectory($scaffoldDirectoryName)
     {
-        $scaffoldDirectory = __DIR__.'/../'.$scaffoldDirectoryName;
-
-        if (PHP_OS_FAMILY == 'Windows') {
-            $scaffoldDirectory = preg_replace('/\//', '\\', $scaffoldDirectory);
-        }
+        $scaffoldDirectory = __DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.$scaffoldDirectoryName;
 
         if (file_exists($scaffoldDirectory)) {
             if (PHP_OS_FAMILY == 'Windows') {
@@ -66,12 +66,14 @@ class NewCommandTest extends TestCase
         $app = new Application('Laravel Installer');
         $app->add(new NewCommand);
 
+        echo "Current dir: " . getcwd() . "\n";
+
         $tester = new CommandTester($app->find('new'));
 
         $statusCode = $tester->execute($parameters);
 
         $this->assertSame(0, $statusCode);
-        $this->assertDirectoryExists($scaffoldDirectory.'/vendor');
-        $this->assertFileExists($scaffoldDirectory.'/.env');
+        $this->assertDirectoryExists($scaffoldDirectory.DIRECTORY_SEPARATOR.'vendor');
+        $this->assertFileExists($scaffoldDirectory.DIRECTORY_SEPARATOR.'.env');
     }
 }

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -14,16 +14,7 @@ class NewCommandTest extends TestCase
         $scaffoldDirectoryName = 'tests-output/my-app';
         $scaffoldDirectory = $this->prepareScaffoldDirectory($scaffoldDirectoryName);
 
-        $app = new Application('Laravel Installer');
-        $app->add(new NewCommand);
-
-        $tester = new CommandTester($app->find('new'));
-
-        $statusCode = $tester->execute(['name' => $scaffoldDirectoryName]);
-
-        $this->assertSame(0, $statusCode);
-        $this->assertDirectoryExists($scaffoldDirectory.'/vendor');
-        $this->assertFileExists($scaffoldDirectory.'/.env');
+        $this->assertApplicationIsScaffolded($scaffoldDirectory, ['name' => $scaffoldDirectoryName]);
     }
 
     public function test_it_can_scaffold_a_new_laravel_app_in_the_current_directory()
@@ -35,19 +26,17 @@ class NewCommandTest extends TestCase
         mkdir($scaffoldDirectory);
         chdir($scaffoldDirectory);
 
-        $app = new Application('Laravel Installer');
-        $app->add(new NewCommand);
-
-        $tester = new CommandTester($app->find('new'));
-
-        $statusCode = $tester->execute([]);
-
-        $this->assertSame(0, $statusCode);
-        $this->assertDirectoryExists($scaffoldDirectory.'/vendor');
-        $this->assertFileExists($scaffoldDirectory.'/.env');
+        $this->assertApplicationIsScaffolded($scaffoldDirectory, []);
     }
 
-    public function prepareScaffoldDirectory($scaffoldDirectoryName)
+    /**
+     * Removes the scaffold test directory if existing and returns the absolute scaffold directory path.
+     *
+     * @param $scaffoldDirectoryName
+     *
+     * @return string
+     */
+    protected function prepareScaffoldDirectory($scaffoldDirectoryName)
     {
         $scaffoldDirectory = __DIR__.'/../'.$scaffoldDirectoryName;
 
@@ -60,5 +49,25 @@ class NewCommandTest extends TestCase
         }
 
         return $scaffoldDirectory;
+    }
+
+    /**
+     * Initiates the application scaffolding in the given directory and with the specified parameters and asserts it succeeded.
+     *
+     * @param string $scaffoldDirectory
+     * @param array  $parameters
+     */
+    protected function assertApplicationIsScaffolded(string $scaffoldDirectory, array $parameters): void
+    {
+        $app = new Application('Laravel Installer');
+        $app->add(new NewCommand);
+
+        $tester = new CommandTester($app->find('new'));
+
+        $statusCode = $tester->execute($parameters);
+
+        $this->assertSame(0, $statusCode);
+        $this->assertDirectoryExists($scaffoldDirectory . '/vendor');
+        $this->assertFileExists($scaffoldDirectory . '/.env');
     }
 }

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -19,7 +19,7 @@ class NewCommandTest extends TestCase
 
     public function test_it_can_scaffold_a_new_laravel_app_in_the_current_directory()
     {
-        $scaffoldDirectoryName = 'tests-output'.DIRECTORY_SEPARATOR.'my-app';
+        $scaffoldDirectoryName = 'tests-output'.DIRECTORY_SEPARATOR.'my-app-cwd';
         $scaffoldDirectory = $this->prepareScaffoldDirectory($scaffoldDirectoryName);
 
         // Create directory and change into it.

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -67,7 +67,7 @@ class NewCommandTest extends TestCase
         $statusCode = $tester->execute($parameters);
 
         $this->assertSame(0, $statusCode);
-        $this->assertDirectoryExists($scaffoldDirectory . '/vendor');
-        $this->assertFileExists($scaffoldDirectory . '/.env');
+        $this->assertDirectoryExists($scaffoldDirectory.'/vendor');
+        $this->assertFileExists($scaffoldDirectory.'/.env');
     }
 }


### PR DESCRIPTION
This pull request fixes #161 .

The path in `$directory` is now expanded to an absolute directory using `realpath()`.
Tested on Linux, could not test on Windows (but I hope the CI pipeline will take care of that).