### PR TITLE
Would be useful if DB_DATABASE is updated on the .env.example as well

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -109,6 +109,12 @@ class NewCommand extends Command
                     'DB_DATABASE='.str_replace('-', '_', strtolower($name)),
                     $directory.'/.env'
                 );
+
+                $this->replaceInFile(
+                    'DB_DATABASE=laravel',
+                    'DB_DATABASE='.str_replace('-', '_', strtolower($name)),
+                    $directory.'/.env.example'
+                );
             }
 
             if ($input->getOption('jet')) {


### PR DESCRIPTION
At the moment running `laravel new orion` only update `DB_DATABASE=orion` on `.env` and not `.env.example`. But I think it might be useful if `.env.example` should be updated as well since this is only used once by the repository manager/project manager.