### PR TITLE
[4.x] PHP 8 Support Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip
+          extensions: dom, curl, libxml, mbstring, zip, fileinfo
           tools: composer:v2
           coverage: none
           ini-values: memory_limit=512M


### PR DESCRIPTION
`league/flysystem` requires `fileinfo`

![image](https://user-images.githubusercontent.com/13331388/97773195-180f7f80-1b4e-11eb-991f-08791f84ff13.png)
