### PR TITLE
Fix Application already exist error when creating a new app on curren…

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -70,7 +70,7 @@ class NewCommand extends Command
 
         $name = $input->getArgument('name');
 
-        $directory = $name && $name !== '.' ? getcwd().'/'.$name : '.';
+        $directory = $name && $name !== '.' ? getcwd().'/'.$name : getcwd();
 
         $version = $this->getVersion($input);
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -43,7 +43,7 @@ class NewCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $installJetstream = $input->getOption('jet') ||
-            ($input->getOption('prompt-jetstream') && (new SymfonyStyle($input, $output))->confirm('Would you like to install the Laravel Jetstream application scaffolding?', false));
+                            ($input->getOption('prompt-jetstream') && (new SymfonyStyle($input, $output))->confirm('Would you like to install the Laravel Jetstream application scaffolding?', false));
 
         if ($installJetstream) {
             $output->write(PHP_EOL."<fg=magenta>
@@ -55,8 +55,8 @@ class NewCommand extends Command
             $stack = $this->jetstreamStack($input, $output);
 
             $teams = $input->getOption('teams') === true
-                ? (bool) $input->getOption('teams')
-                : (new SymfonyStyle($input, $output))->confirm('Will your application use teams?', false);
+                    ? (bool) $input->getOption('teams')
+                    : (new SymfonyStyle($input, $output))->confirm('Will your application use teams?', false);
         } else {
             $output->write(PHP_EOL.'<fg=red> _                               _
 | |                             | |
@@ -78,7 +78,7 @@ class NewCommand extends Command
             $this->verifyApplicationDoesntExist($directory);
         }
 
-        if ($input->getOption('force') && (empty($name)  || $name === '.')) {
+        if ($input->getOption('force') && (empty($name) || $name === '.')) {
             throw new RuntimeException('Cannot use --force option when using current directory for installation!');
         }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -43,7 +43,7 @@ class NewCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $installJetstream = $input->getOption('jet') ||
-                            ($input->getOption('prompt-jetstream') && (new SymfonyStyle($input, $output))->confirm('Would you like to install the Laravel Jetstream application scaffolding?', false));
+            ($input->getOption('prompt-jetstream') && (new SymfonyStyle($input, $output))->confirm('Would you like to install the Laravel Jetstream application scaffolding?', false));
 
         if ($installJetstream) {
             $output->write(PHP_EOL."<fg=magenta>
@@ -55,8 +55,8 @@ class NewCommand extends Command
             $stack = $this->jetstreamStack($input, $output);
 
             $teams = $input->getOption('teams') === true
-                    ? (bool) $input->getOption('teams')
-                    : (new SymfonyStyle($input, $output))->confirm('Will your application use teams?', false);
+                ? (bool) $input->getOption('teams')
+                : (new SymfonyStyle($input, $output))->confirm('Will your application use teams?', false);
         } else {
             $output->write(PHP_EOL.'<fg=red> _                               _
 | |                             | |
@@ -78,7 +78,7 @@ class NewCommand extends Command
             $this->verifyApplicationDoesntExist($directory);
         }
 
-        if ($input->getOption('force') && $directory === '.') {
+        if ($input->getOption('force') && (empty($name)  || $name === '.')) {
             throw new RuntimeException('Cannot use --force option when using current directory for installation!');
         }
 
@@ -88,7 +88,7 @@ class NewCommand extends Command
             $composer." create-project laravel/laravel \"$directory\" $version --remove-vcs --prefer-dist",
         ];
 
-        if ($directory != '.' && $input->getOption('force')) {
+        if ($name && $name !== '.' && $input->getOption('force')) {
             if (PHP_OS_FAMILY == 'Windows') {
                 array_unshift($commands, "rd /s /q \"$directory\"");
             } else {


### PR DESCRIPTION
 This pull request fixes #161 .


A similar PR was rejected claiming that current directory is not supported, however the name argument is still label as optional  in [NewCommand.php#L27](https://github.com/laravel/installer/blob/master/src/NewCommand.php#L27) allowing for **laravel new**  to be run on the current directory

In previous versions **laravel new**  and **laravel new .** were valid options, and  [NewCommand.php#L73](https://github.com/laravel/installer/blob/master/src/NewCommand.php#L73) still considers that name may be empty  or . 
it's just incorrectly setting the directory to . instead of the current path

