### PR TITLE
Git support

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -26,7 +26,8 @@ class NewCommand extends Command
             ->setDescription('Create a new Laravel application')
             ->addArgument('name', InputArgument::REQUIRED)
             ->addOption('dev', null, InputOption::VALUE_NONE, 'Installs the latest "development" release')
-            ->addOption('git', null, InputOption::VALUE_NONE, 'Initialize a Git repository')
+            ->addOption('repo', null, InputOption::VALUE_NONE, 'Initialize a Git repository')
+            ->addOption('github', null, InputOption::VALUE_OPTIONAL, 'Create a new repository on GitHub')
             ->addOption('jet', null, InputOption::VALUE_NONE, 'Installs the Laravel Jetstream scaffolding')
             ->addOption('stack', null, InputOption::VALUE_OPTIONAL, 'The Jetstream stack that should be installed')
             ->addOption('teams', null, InputOption::VALUE_NONE, 'Indicates whether Jetstream should be scaffolded with team support')
@@ -126,8 +127,8 @@ class NewCommand extends Command
                 $this->installJetstream($directory, $stack, $teams, $input, $output);
             }
 
-            if ($input->getOption('git')) {
-                $this->setUpGitRepository($directory, $input, $output);
+            if ($input->hasOption('repo') || $input->hasOption('github')) {
+                $this->createRepository($name, $directory, $input, $output);
             }
 
             $output->writeln(PHP_EOL.'<comment>Application ready! Build something amazing.</comment>');
@@ -188,14 +189,15 @@ class NewCommand extends Command
     }
 
     /**
-     * Initialize a Git repository.
+     * Create a Git repository and optionally push it to GitHub.
      *
+     * @param  string  $name
      * @param  string  $directory
      * @param  \Symfony\Component\Console\Input\InputInterface  $input
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @return void
      */
-    protected function setUpGitRepository(string $directory, InputInterface $input, OutputInterface $output)
+    protected function createRepository(string $name, string $directory, InputInterface $input, OutputInterface $output)
     {
         chdir($directory);
 
@@ -204,6 +206,13 @@ class NewCommand extends Command
             'git add .',
             'git commit -q -m "Set up a fresh Laravel app"',
         ];
+
+        if ($input->hasOption('github')) {
+            $flags = $input->getOption('github') ?: "--private";
+
+            $commands[] = "gh repo create $name -y $flags";
+            $commands[] = "git push -q -u origin main";
+        }
 
         $this->runCommands($commands, $input, $output);
     }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -26,7 +26,7 @@ class NewCommand extends Command
             ->setDescription('Create a new Laravel application')
             ->addArgument('name', InputArgument::REQUIRED)
             ->addOption('dev', null, InputOption::VALUE_NONE, 'Installs the latest "development" release')
-            ->addOption('repo', null, InputOption::VALUE_NONE, 'Initialize a Git repository')
+            ->addOption('git', null, InputOption::VALUE_NONE, 'Initialize a Git repository')
             ->addOption('github', null, InputOption::VALUE_OPTIONAL, 'Create a new repository on GitHub')
             ->addOption('jet', null, InputOption::VALUE_NONE, 'Installs the Laravel Jetstream scaffolding')
             ->addOption('stack', null, InputOption::VALUE_OPTIONAL, 'The Jetstream stack that should be installed')
@@ -123,12 +123,16 @@ class NewCommand extends Command
                 );
             }
 
+            if ($input->hasOption('git') || $input->hasOption('github')) {
+                $this->createRepository($directory, $input, $output);
+            }
+
             if ($installJetstream) {
                 $this->installJetstream($directory, $stack, $teams, $input, $output);
             }
 
-            if ($input->hasOption('repo') || $input->hasOption('github')) {
-                $this->createRepository($name, $directory, $input, $output);
+            if ($input->hasOption('github')) {
+                $this->pushToGitHub($name, $directory, $input, $output);
             }
 
             $output->writeln(PHP_EOL.'<comment>Application ready! Build something amazing.</comment>');
@@ -159,6 +163,8 @@ class NewCommand extends Command
         ]);
 
         $this->runCommands($commands, $input, $output);
+
+        $this->commitChanges('Install Jetstream', $directory, $input, $output);
     }
 
     /**
@@ -189,15 +195,14 @@ class NewCommand extends Command
     }
 
     /**
-     * Create a Git repository and optionally push it to GitHub.
+     * Create a Git repository and commit the base Laravel skeleton.
      *
-     * @param  string  $name
      * @param  string  $directory
      * @param  \Symfony\Component\Console\Input\InputInterface  $input
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @return void
      */
-    protected function createRepository(string $name, string $directory, InputInterface $input, OutputInterface $output)
+    protected function createRepository(string $directory, InputInterface $input, OutputInterface $output)
     {
         chdir($directory);
 
@@ -207,12 +212,62 @@ class NewCommand extends Command
             'git commit -q -m "Set up a fresh Laravel app"',
         ];
 
-        if ($input->hasOption('github')) {
-            $flags = $input->getOption('github') ?: "--private";
+        $this->runCommands($commands, $input, $output);
+    }
 
-            $commands[] = "gh repo create $name -y $flags";
-            $commands[] = "git push -q -u origin main";
+    /**
+     * Commit any changes in the current working directory.
+     *
+     * @param  string  $message
+     * @param  string  $directory
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
+     */
+    protected function commitChanges(string $message, string $directory, InputInterface $input, OutputInterface $output)
+    {
+        if (! $input->hasOption('git') && ! $input->hasOption('github')) {
+            return;
         }
+
+        chdir($directory);
+
+        $commands = [
+            'git add .',
+            "git commit -q -m \"$message\"",
+        ];
+
+        $this->runCommands($commands, $input, $output);
+    }
+
+    /**
+     * Create a GitHub repository and push the git log to it.
+     *
+     * @param  string  $name
+     * @param  string  $directory
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
+     */
+    protected function pushToGitHub(string $name, string $directory, InputInterface $input, OutputInterface $output)
+    {
+        $process = new Process(['gh', 'auth', 'status']);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            $output->writeln('Warning: make sure the "gh" CLI tool is installed and that you\'re authenticated to GitHub. Skipping...');
+
+            return;
+        }
+
+        chdir($directory);
+
+        $flags = $input->getOption('github') ?: "--private";
+
+        $commands = [
+            "gh repo create $name -y $flags",
+            'git push -q -u origin main',
+        ];
 
         $this->runCommands($commands, $input, $output);
     }
@@ -267,7 +322,7 @@ class NewCommand extends Command
      * @param  array  $commands
      * @param  \Symfony\Component\Console\Input\InputInterface  $input
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
-     * @return Process
+     * @return \Symfony\Component\Process\Process
      */
     protected function runCommands($commands, InputInterface $input, OutputInterface $output)
     {

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -26,6 +26,7 @@ class NewCommand extends Command
             ->setDescription('Create a new Laravel application')
             ->addArgument('name', InputArgument::REQUIRED)
             ->addOption('dev', null, InputOption::VALUE_NONE, 'Installs the latest "development" release')
+            ->addOption('git', null, InputOption::VALUE_NONE, 'Initialize a Git repository')
             ->addOption('jet', null, InputOption::VALUE_NONE, 'Installs the Laravel Jetstream scaffolding')
             ->addOption('stack', null, InputOption::VALUE_OPTIONAL, 'The Jetstream stack that should be installed')
             ->addOption('teams', null, InputOption::VALUE_NONE, 'Indicates whether Jetstream should be scaffolded with team support')
@@ -125,6 +126,10 @@ class NewCommand extends Command
                 $this->installJetstream($directory, $stack, $teams, $input, $output);
             }
 
+            if ($input->getOption('git')) {
+                $this->setUpGitRepository($directory, $input, $output);
+            }
+
             $output->writeln(PHP_EOL.'<comment>Application ready! Build something amazing.</comment>');
         }
 
@@ -180,6 +185,27 @@ class NewCommand extends Command
         $output->write(PHP_EOL);
 
         return $helper->ask($input, new SymfonyStyle($input, $output), $question);
+    }
+
+    /**
+     * Initialize a Git repository.
+     *
+     * @param  string  $directory
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
+     */
+    protected function setUpGitRepository(string $directory, InputInterface $input, OutputInterface $output)
+    {
+        chdir($directory);
+
+        $commands = [
+            'git init -q .',
+            'git add .',
+            'git commit -q -m "Set up a fresh Laravel app"',
+        ];
+
+        $this->runCommands($commands, $input, $output);
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -207,7 +207,7 @@ class NewCommand extends Command
         chdir($directory);
 
         $commands = [
-            'git init -q .',
+            'git init -q -b main .',
             'git add .',
             'git commit -q -m "Set up a fresh Laravel app"',
         ];

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -262,7 +262,7 @@ class NewCommand extends Command
 
         chdir($directory);
 
-        $flags = $input->getOption('github') ?: "--private";
+        $flags = $input->getOption('github') ?: '--private';
 
         $commands = [
             "gh repo create $name -y $flags",


### PR DESCRIPTION
This PR adds git support to the Laravel installer. It'll allow users to immediately set up a Git repository with a fresh Laravel app committed into the Git history. Additionally, when using the `--github` flag, the installer will use [GitHub's `gh` CLI tool](https://cli.github.com) under the hood to push the project to a private GitHub repo under the user's GitHub account. This'll make getting up an running with a new Laravel project that more easier.

Set up a new Laravel project and initialize a repo with the base skeleton committed:

```bash
laravel new my-app.com --git
```

The same as above but also automatically create a private GitHub repository:

```bash
laravel new my-app.com --github
```

The repo will then be available at `github.com/<your-account/my-app.com`.

The same as above but with Jetstream committed separately:

```bash
laravel new my-app.com --jet --github
```

Pass flags for `gh repo create`:

```bash
laravel new my-app.com --github="--public --team laravel"
```

The `git` flag assumes you've properly installed and configured Git. The `github` flag assumes you've properly installed the `gh` CLI tool and are authenticated with GitHub.