### PR TITLE
Improve Git push

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -266,7 +266,7 @@ class NewCommand extends Command
 
         $commands = [
             "gh repo create $name -y $flags",
-            'git push -q -u origin main',
+            "GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c credential.helper='!gh auth git-credential' push -q -u origin main",
         ];
 
         $this->runCommands($commands, $input, $output);


### PR DESCRIPTION
After talking to some of my GitHub contacts they gave me a tip for a safer way to do a `git push` after creating the GitHub repo. Doing so will allow us to remove the note about the `gh_protocol` in the docs as it won't matter anymore what protocol you use.