### PR TITLE
Add organisation flag

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -28,7 +28,7 @@ class NewCommand extends Command
             ->addOption('dev', null, InputOption::VALUE_NONE, 'Installs the latest "development" release')
             ->addOption('git', null, InputOption::VALUE_NONE, 'Initialize a Git repository')
             ->addOption('github', null, InputOption::VALUE_OPTIONAL, 'Create a new repository on GitHub', false)
-            ->addOption('organisation', null, InputOption::VALUE_REQUIRED, 'Choose the GitHub organisation to create the new repository for.')
+            ->addOption('organization', null, InputOption::VALUE_REQUIRED, 'The GitHub organization to create the new repository for')
             ->addOption('jet', null, InputOption::VALUE_NONE, 'Installs the Laravel Jetstream scaffolding')
             ->addOption('stack', null, InputOption::VALUE_OPTIONAL, 'The Jetstream stack that should be installed')
             ->addOption('teams', null, InputOption::VALUE_NONE, 'Indicates whether Jetstream should be scaffolded with team support')
@@ -263,7 +263,8 @@ class NewCommand extends Command
 
         chdir($directory);
 
-        $name = $input->getOption('organisation') ? $input->getOption('organisation')."/$name" : $name;
+        $name = $input->getOption('organization') ? $input->getOption('organization')."/$name" : $name;
+
         $flags = $input->getOption('github') ?: '--private';
 
         $commands = [

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -28,6 +28,7 @@ class NewCommand extends Command
             ->addOption('dev', null, InputOption::VALUE_NONE, 'Installs the latest "development" release')
             ->addOption('git', null, InputOption::VALUE_NONE, 'Initialize a Git repository')
             ->addOption('github', null, InputOption::VALUE_OPTIONAL, 'Create a new repository on GitHub', false)
+            ->addOption('organisation', null, InputOption::VALUE_REQUIRED, 'Choose the GitHub organisation to create the new repository for.')
             ->addOption('jet', null, InputOption::VALUE_NONE, 'Installs the Laravel Jetstream scaffolding')
             ->addOption('stack', null, InputOption::VALUE_OPTIONAL, 'The Jetstream stack that should be installed')
             ->addOption('teams', null, InputOption::VALUE_NONE, 'Indicates whether Jetstream should be scaffolded with team support')
@@ -262,6 +263,7 @@ class NewCommand extends Command
 
         chdir($directory);
 
+        $name = $input->getOption('organisation') ? $input->getOption('organisation')."/$name" : $name;
         $flags = $input->getOption('github') ?: '--private';
 
         $commands = [


### PR DESCRIPTION
Apparently I completely misunderstood the usage of `--team` and therefor it's currently impossible to create a GitHub repo under an organisation. I've therefor added a new `--organisation` flag that can be used to create the repo under a specific GitHub organisation. 

After this PR is merged I'll update the blog post and docs.