### PR TITLE
Add support for oldest versions of Git

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -211,9 +211,10 @@ class NewCommand extends Command
         $branch = $input->getOption('branch') ?: 'main';
 
         $commands = [
-            "git init -q -b {$branch} .",
+            'git init -q',
             'git add .',
             'git commit -q -m "Set up a fresh Laravel app"',
+            "git branch -M {$branch}",
         ];
 
         $this->runCommands($commands, $input, $output);


### PR DESCRIPTION
This PR will add support for git version less than 2.28.0. Which is the only version that has the `-b` option for creating a repo during the initialization.
This will help Linux users which is by default to have Git version less than 2.28.0.