### PR TITLE
Change default `APP_NAME` to the project name

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -107,6 +107,12 @@ class NewCommand extends Command
         if (($process = $this->runCommands($commands, $input, $output))->isSuccessful()) {
             if ($name !== '.') {
                 $this->replaceInFile(
+                    'APP_NAME=Laravel',
+                    'APP_NAME="'.ucwords($name).'"',
+                    $directory.'/.env'
+                );
+
+                $this->replaceInFile(
                     'APP_URL=http://localhost',
                     'APP_URL=http://'.$name.'.test',
                     $directory.'/.env'


### PR DESCRIPTION
This pull request will make the `APP_NAME` variable hold the project name instead of the default value (Laravel).