### PR TITLE
Fix new command failing without no-ansi option

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -334,7 +334,7 @@ class NewCommand extends Command
      */
     protected function runCommands($commands, InputInterface $input, OutputInterface $output, array $env = [])
     {
-        if ($input->getOption('no-ansi')) {
+        if ($input->hasOption('no-ansi')) {
             $commands = array_map(function ($value) {
                 if (substr($value, 0, 5) === 'chmod') {
                     return $value;


### PR DESCRIPTION
### Fixed

- Fixes the `laravel new` command failing without the `no-ansi` option

---

The underlying Symfony `Input::getOption` ([source](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Console/Input/Input.php#L150)) fails when the option is missing in the command definition, so I think we need to call it after a `$input->hasOption()` check. Not sure how this has been working before (as it looks like things haven't changed in a while both in Symfony console and here), but it broke today on my end when running `laravel new ...`.

Running the tests was also failing over here and I enabled the workflows on my fork repository to [show it breaking](https://github.com/tonysm/installer/actions/runs/894362202). I was getting the same error locally:

![image](https://user-images.githubusercontent.com/1178621/120250792-c9e26c00-c255-11eb-99e6-64a00498c234.png)

I'm not sure about the other `getOption` calls in the NewCommand file, though.