### PR TITLE
Use isDecorated for no-ansi detection

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -334,7 +334,7 @@ class NewCommand extends Command
      */
     protected function runCommands($commands, InputInterface $input, OutputInterface $output, array $env = [])
     {
-        if ($input->hasOption('no-ansi')) {
+        if (! $output->isDecorated()) {
             $commands = array_map(function ($value) {
                 if (substr($value, 0, 5) === 'chmod') {
                     return $value;


### PR DESCRIPTION
This PR fixes the previous `no-ansi` breakage by making use of the `isDecorated` method on the Symfony output to make sure that no output is colorized when the `no-ansi` flag is passed.

See https://github.com/symfony/symfony/pull/39642#issuecomment-852006010