### PR TITLE
[4.x] added support for custom template

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -34,7 +34,8 @@ class NewCommand extends Command
             ->addOption('stack', null, InputOption::VALUE_OPTIONAL, 'The Jetstream stack that should be installed')
             ->addOption('teams', null, InputOption::VALUE_NONE, 'Indicates whether Jetstream should be scaffolded with team support')
             ->addOption('prompt-jetstream', null, InputOption::VALUE_NONE, 'Issues a prompt to determine if Jetstream should be installed')
-            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Forces install even if the directory already exists');
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Forces install even if the directory already exists')
+            ->addOption('template', 't', InputOption::VALUE_OPTIONAL, 'The laravel template to use', 'laravel/laravel');
     }
 
     /**
@@ -74,6 +75,8 @@ class NewCommand extends Command
 
         $name = $input->getArgument('name');
 
+        $template = $input->getOption('template');
+
         $directory = $name !== '.' ? getcwd().'/'.$name : '.';
 
         $version = $this->getVersion($input);
@@ -89,7 +92,7 @@ class NewCommand extends Command
         $composer = $this->findComposer();
 
         $commands = [
-            $composer." create-project laravel/laravel \"$directory\" $version --remove-vcs --prefer-dist",
+            $composer." create-project $template \"$directory\" $version --remove-vcs --prefer-dist",
         ];
 
         if ($directory != '.' && $input->getOption('force')) {


### PR DESCRIPTION
These changes enables users to specify an optional custom template for their new laravel project.

Unlike other framework's installers such as `react-native-init` accepts optional custom template option to be used.

## Usage
Created an example template which the welcome page title was changed from `Laravel` to `Laravel Example Template`
```bash
laravel new blog --template myckhel/laravel-template-example
```

## Prerequisites
- Template repository should have been submited to composer's [packagist](https://packagist.org)
- Template repository should have at least a release tag for it to be installed.
- Template repository should have a `master` branch if the `--dev` installer option is specified as installer expects.