### PR TITLE
Respect git global config for a default branch

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -27,7 +27,7 @@ class NewCommand extends Command
             ->addArgument('name', InputArgument::REQUIRED)
             ->addOption('dev', null, InputOption::VALUE_NONE, 'Installs the latest "development" release')
             ->addOption('git', null, InputOption::VALUE_NONE, 'Initialize a Git repository')
-            ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'The branch that should be created for a new repository', $this->defaultBranch('main'))
+            ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'The branch that should be created for a new repository', $this->defaultBranch())
             ->addOption('github', null, InputOption::VALUE_OPTIONAL, 'Create a new repository on GitHub', false)
             ->addOption('organization', null, InputOption::VALUE_REQUIRED, 'The GitHub organization to create the new repository for')
             ->addOption('jet', null, InputOption::VALUE_NONE, 'Installs the Laravel Jetstream scaffolding')
@@ -148,14 +148,14 @@ class NewCommand extends Command
      *
      * @return string
      */
-    protected function defaultBranch($default)
+    protected function defaultBranch()
     {
         $process = new Process(['git', 'config', '--global', 'init.defaultBranch']);
         $process->run();
 
         $output = trim($process->getOutput());
 
-        return $process->isSuccessful() && $output ? $output : $default;
+        return $process->isSuccessful() && $output ? $output : 'main';
     }
 
     /**
@@ -223,7 +223,7 @@ class NewCommand extends Command
     {
         chdir($directory);
 
-        $branch = $input->getOption('branch') ?: $this->defaultBranch('main');
+        $branch = $input->getOption('branch') ?: $this->defaultBranch();
 
         $commands = [
             'git init -q',
@@ -284,7 +284,7 @@ class NewCommand extends Command
 
         $name = $input->getOption('organization') ? $input->getOption('organization')."/$name" : $name;
         $flags = $input->getOption('github') ?: '--private';
-        $branch = $input->getOption('branch') ?: $this->defaultBranch('main');
+        $branch = $input->getOption('branch') ?: $this->defaultBranch();
 
         $commands = [
             "gh repo create {$name} -y {$flags}",

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -27,7 +27,7 @@ class NewCommand extends Command
             ->addArgument('name', InputArgument::REQUIRED)
             ->addOption('dev', null, InputOption::VALUE_NONE, 'Installs the latest "development" release')
             ->addOption('git', null, InputOption::VALUE_NONE, 'Initialize a Git repository')
-            ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'The branch that should be created for a new repository', 'main')
+            ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'The branch that should be created for a new repository', $this->defaultBranch('main'))
             ->addOption('github', null, InputOption::VALUE_OPTIONAL, 'Create a new repository on GitHub', false)
             ->addOption('organization', null, InputOption::VALUE_REQUIRED, 'The GitHub organization to create the new repository for')
             ->addOption('jet', null, InputOption::VALUE_NONE, 'Installs the Laravel Jetstream scaffolding')
@@ -144,6 +144,21 @@ class NewCommand extends Command
     }
 
     /**
+     * Return `git config --global init.defaultBranch` if set or default to `main`
+     *
+     * @return string
+     */
+    protected function defaultBranch($default)
+    {
+        $process = new Process(['git', 'config', '--global', 'init.defaultBranch']);
+        $process->run();
+
+        $output = trim($process->getOutput());
+
+        return $process->isSuccessful() && $output ? $output : $default;
+    }
+
+    /**
      * Install Laravel Jetstream into the application.
      *
      * @param  string  $directory
@@ -208,7 +223,7 @@ class NewCommand extends Command
     {
         chdir($directory);
 
-        $branch = $input->getOption('branch') ?: 'main';
+        $branch = $input->getOption('branch') ?: $this->defaultBranch('main');
 
         $commands = [
             'git init -q',
@@ -269,7 +284,7 @@ class NewCommand extends Command
 
         $name = $input->getOption('organization') ? $input->getOption('organization')."/$name" : $name;
         $flags = $input->getOption('github') ?: '--private';
-        $branch = $input->getOption('branch') ?: 'main';
+        $branch = $input->getOption('branch') ?: $this->defaultBranch('main');
 
         $commands = [
             "gh repo create {$name} -y {$flags}",

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -144,7 +144,7 @@ class NewCommand extends Command
     }
 
     /**
-     * Return `git config --global init.defaultBranch` if set or default to `main`
+     * Return `git config --global init.defaultBranch` if set or default to `main`.
      *
      * @return string
      */


### PR DESCRIPTION
Git provides a global configuration to override the default branch when a new repository is initialized.
Even though laravel/installer provides a way to override the default branch name, laravel/installer does respect git global configurations.

[init.defaultBranch:- Allows overriding the default branch name e.g. when initializing a new repository.](https://git-scm.com/docs/git-config#Documentation/git-config.txt-initdefaultBranch)