### PR TITLE
Always run NPM install

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -176,7 +176,7 @@ class NewCommand extends Command
         $commands = array_filter([
             $this->findComposer().' require laravel/jetstream',
             trim(sprintf(PHP_BINARY.' artisan jetstream:install %s %s', $stack, $teams ? '--teams' : '')),
-            $stack === 'inertia' ? 'npm install && npm run dev' : null,
+            'npm install && npm run dev',
             PHP_BINARY.' artisan storage:link',
         ]);
 


### PR DESCRIPTION
The first thing I always do after creating a new Laravel app with the Livewire stack is running NPM install and compiling the frontend dependencies so I think we should just always run this for both stacks.
