### PR TITLE
Show the laravel version after the installation

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -137,6 +137,10 @@ class NewCommand extends Command
                 $this->pushToGitHub($name, $directory, $input, $output);
             }
 
+            chdir($directory);
+
+            $this->runCommands([PHP_BINARY.' artisan --version'], $input, $output);
+
             $output->writeln(PHP_EOL.'<comment>Application ready! Build something amazing.</comment>');
         }
 


### PR DESCRIPTION
After installation, we all want to know which version of laravel was installed IMHO.
This pull request makes it possible without you having checking by yourself.

If you use composer directory to install laravel, this doesn't work.
But I think it can't be helped.

![2022-03-23_22h25_27](https://user-images.githubusercontent.com/14008307/159710145-198e218d-dec8-4b55-be8c-1dcdeff1f732.png)
