### PR TITLE
Add node-packages option to determine if installer should install node packages or not

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -84,7 +84,7 @@ class NewCommand extends Command
 
         $version = $this->getVersion($input);
 
-        if($installNodePackages){
+        if ($installNodePackages) {
             $nodePackageManager = $this->getNodePackageManager($input, $output);
         }
 
@@ -424,16 +424,15 @@ class NewCommand extends Command
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @return string
      */
-
     protected function getNodePackageManager(InputInterface $input, OutputInterface $output)
     {
-        if($input->getOption('yarn')) {
+        if ($input->getOption('yarn')) {
             return 'yarn';
         }
 
         $packageManagers = [
-           'npm',
-           'yarn',
+            'npm',
+            'yarn',
         ];
 
         $helper = $this->getHelper('question');
@@ -456,7 +455,6 @@ class NewCommand extends Command
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @return void
      */
-
     protected function installNodePackages(string $directory, InputInterface $input, OutputInterface $output, $nodePackageManager)
     {
         chdir($directory);

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -438,21 +438,19 @@ class NewCommand extends Command
         $helper = $this->getHelper('question');
 
         $question = new ChoiceQuestion('Which node package manager do you want to use?', $packageManagers);
-        
+
         $output->write(PHP_EOL);
 
         return $helper->ask($input, new SymfonyStyle($input, $output), $question);
-
     }
 
     /**
      * Install node packages.
      *
      * @param  string  $directory
-     * @param  string  $stack
-     * @param  bool  $teams
      * @param  \Symfony\Component\Console\Input\InputInterface  $input
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @param  string  $nodePackageManager
      * @return void
      */
     protected function installNodePackages(string $directory, InputInterface $input, OutputInterface $output, $nodePackageManager)


### PR DESCRIPTION
If you provided `--node-packages` option the installer will  install `node_modules`
for you after `laravel` installation .

```sh
laravel new my-project --node-packages
```
![new-laravel-project](https://user-images.githubusercontent.com/57622665/174456872-2b36e4d4-2c58-48d0-84d3-8be3cc66df62.png)

and with `jetstream`

```sh
laravel new my-project --jet
```

![new-laravel-project-with-jet](https://user-images.githubusercontent.com/57622665/174457001-ddfccac6-8d4e-4ca5-9874-1b1127688077.png)


