### PR TITLE
Check directory before deleting in Windows OS

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -94,7 +94,7 @@ class NewCommand extends Command
 
         if ($directory != '.' && $input->getOption('force')) {
             if (PHP_OS_FAMILY == 'Windows') {
-                array_unshift($commands, "rd /s /q \"$directory\"");
+                array_unshift($commands, "(if exist \"$directory\" rd /s /q \"$directory\")");
             } else {
                 array_unshift($commands, "rm -rf \"$directory\"");
             }


### PR DESCRIPTION
On Windows OS when using the `--force` option and the directory does not exist it will throw an error "The system cannot find the file specified.".

This PR ensures the directory exists before deleting.

![image](https://user-images.githubusercontent.com/27954794/177538577-9331641a-baf8-4d26-8e50-73190f5ec7e3.png)

Tested on Windows 10 Pro Version 10.0.19044 Build 19044