### PR TITLE
Simplify push to GitHub

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -289,8 +289,7 @@ class NewCommand extends Command
         $branch = $input->getOption('branch') ?: $this->defaultBranch();
 
         $commands = [
-            "gh repo create {$name} --source=. {$flags}",
-            "git -c credential.helper= -c credential.helper='!gh auth git-credential' push -q -u origin {$branch}",
+            "gh repo create {$name} --source=. --push {$flags}",
         ];
 
         $this->runCommands($commands, $input, $output, ['GIT_TERMINAL_PROMPT' => 0]);


### PR DESCRIPTION
GitHub has added a new `--push` flag which simplifies the process of pushing the HEAD branch to the newly created repo.

See https://github.com/cli/cli/issues/3209#issuecomment-1161572256