### PR TITLE
Changes APP_URL replacement with name to lower

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -108,7 +108,7 @@ class NewCommand extends Command
             if ($name !== '.') {
                 $this->replaceInFile(
                     'APP_URL=http://localhost',
-                    'APP_URL=http://'.$name.'.test',
+                    'APP_URL=http://'.strtolower($name).'.test',
                     $directory.'/.env'
                 );
 


### PR DESCRIPTION
Although domain names are case-insensitive, browsers rewrite domains to all lowercase.
This PR aims to match this behaviour.
