### PR TITLE
Prevent unresolvable `APP_URL`

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -309,7 +309,7 @@ class NewCommand extends Command
     }
 
     /**
-     * Generate a valid APP_URL.
+     * Generate a valid APP_URL for the given application name.
      *
      * @param  string  $name
      * @return string
@@ -322,7 +322,7 @@ class NewCommand extends Command
     }
 
     /**
-     * Determine whether the given hostname resolves.
+     * Determine whether the given hostname is resolvable.
      *
      * @param  string  $hostname
      * @return bool

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -108,7 +108,7 @@ class NewCommand extends Command
             if ($name !== '.') {
                 $this->replaceInFile(
                     'APP_URL=http://localhost',
-                    'APP_URL=http://'.strtolower($name).'.test',
+                    'APP_URL='.$this->generateAppUrl($name),
                     $directory.'/.env'
                 );
 
@@ -306,6 +306,30 @@ class NewCommand extends Command
         if ((is_dir($directory) || is_file($directory)) && $directory != getcwd()) {
             throw new RuntimeException('Application already exists!');
         }
+    }
+
+    /**
+     * Generate a valid APP_URL.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function generateAppUrl($name)
+    {
+        $hostname = mb_strtolower($name).'.test';
+
+        return $this->canResolveHostname($hostname) ? 'http://'.$hostname : 'http://localhost';
+    }
+
+    /**
+     * Determine whether the given hostname resolves.
+     *
+     * @param  string  $hostname
+     * @return bool
+     */
+    protected function canResolveHostname($hostname)
+    {
+        return gethostbyname($hostname.'.') !== $hostname.'.';
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue where the installer will generate a `*.test` hostname that is unresolvable on many machines.

If the user has not installed Valet (which doesn't exist for Windows and Linux), then the `*.test` hostnames will not resolve unless they have manually set up their DNS to handle it.

This PR solves that by testing whether the `*.test` hostname resolves before using it, otherwise it leaves the `APP_URL` as `http://localhost`.

This is especially useful with Vite, as we output the `APP_URL` to the console to guide users away from visiting the Vite dev server URL directly.