### PR TITLE
Replace APP_URL in .env.example

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -117,6 +117,12 @@ class NewCommand extends Command
                     'DB_DATABASE='.str_replace('-', '_', strtolower($name)),
                     $directory.'/.env'
                 );
+                
+                $this->replaceInFile(
+                    'APP_URL=http://localhost',
+                    'APP_URL='.$this->generateAppUrl($name),
+                    $directory.'/.env.example'
+                );
 
                 $this->replaceInFile(
                     'DB_DATABASE=laravel',


### PR DESCRIPTION
This PR aims to replicate the same behaviour as the .env replacement for APP_URL in the .env.example file.
