### PR TITLE
Remove duplicate `npm install` and `npm run build` steps

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -177,7 +177,6 @@ class NewCommand extends Command
         $commands = array_filter([
             $this->findComposer().' require laravel/jetstream',
             trim(sprintf(PHP_BINARY.' artisan jetstream:install %s %s', $stack, $teams ? '--teams' : '')),
-            'npm install && npm run build',
             PHP_BINARY.' artisan storage:link',
         ]);
 


### PR DESCRIPTION
If https://github.com/laravel/jetstream/pull/1119 is merged, then this installer will no longer need to run the `npm install` and `npm run build` commands as they will be handled by the Jetstream installer instead.