### PR TITLE
Replace PHP version in composer.json

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -431,7 +431,7 @@ class NewCommand extends Command
     /**
      * Replace the default PHP version in composer.json.
      *
-     * @param string $directory
+     * @param  string $directory
      * @return void
      */
     protected function replacePhpVersion(string $directory)

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -431,7 +431,7 @@ class NewCommand extends Command
     /**
      * Replace the default PHP version in composer.json.
      *
-     * @param  string $directory
+     * @param  string  $directory
      * @return void
      */
     protected function replacePhpVersion(string $directory)

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -125,6 +125,8 @@ class NewCommand extends Command
                 );
             }
 
+            $this->replacePhpVersion($directory);
+
             if ($input->getOption('git') || $input->getOption('github') !== false) {
                 $this->createRepository($directory, $input, $output);
             }
@@ -423,6 +425,24 @@ class NewCommand extends Command
         file_put_contents(
             $file,
             str_replace($search, $replace, file_get_contents($file))
+        );
+    }
+
+    /**
+     * Replace the default PHP version in composer.json.
+     *
+     * @param string $directory
+     * @return void
+     */
+    protected function replacePhpVersion(string $directory)
+    {
+        file_put_contents(
+            $file = $directory.'/composer.json',
+            preg_replace(
+                '/"php": ".*"/',
+                '"php": "^'.phpversion().'"',
+                file_get_contents($file)
+            )
         );
     }
 }


### PR DESCRIPTION
The combination between having the default PHP version in `composer.json`, which is `laravel/laravel`'s lowest supported and PHPStorm, creates an illusion that you can't use newer features, unless you change it yourself (which I haven't seen mentioned in the official documentation or the starting guides around the web).
Here is an example - on a new Laravel installation (via `sail` with PHP v8.1.9) I'm getting this "error":

![Screenshot from 2022-09-03 16-40-26](https://user-images.githubusercontent.com/18031220/188314478-00b1e85d-119e-4a2a-b71c-46ea57731103.png)

PHPStorm gives me the option to switch the version, but for newer folks, which would be the people most likely to have this issue, it may not be clear what does this mean. On top of that, PHPStorm gives me this option even if my PHP version is below 8.1, meaning I would later get runtime errors if I chose to switch and use the newer features.