### PR TITLE
Remove `storage:link` command

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -177,7 +177,6 @@ class NewCommand extends Command
         $commands = array_filter([
             $this->findComposer().' require laravel/jetstream',
             trim(sprintf(PHP_BINARY.' artisan jetstream:install %s %s', $stack, $teams ? '--teams' : '')),
-            PHP_BINARY.' artisan storage:link',
         ]);
 
         $this->runCommands($commands, $input, $output);


### PR DESCRIPTION
There is a PR at https://github.com/laravel/jetstream/pull/1133 to run this command via the Jetstream installer instead so that it is run regardless of what method is used to install Jetstream.