### PR TITLE
feature: allow default config to be set, and used

### DIFF
--- a/bin/laravel
+++ b/bin/laravel
@@ -9,5 +9,6 @@ if (file_exists(__DIR__.'/../../../autoload.php')) {
 
 $app = new Symfony\Component\Console\Application('Laravel Installer', '4.3.0');
 $app->add(new Laravel\Installer\Console\NewCommand);
+$app->add(new Laravel\Installer\Console\ConfigureCommand());
 
 $app->run();

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "illuminate/support": "^9.51",
+        "illuminate/support": "^8.83",
         "symfony/console": "^4.0|^5.0|^6.0",
         "symfony/process": "^4.2|^5.0|^6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
+        "illuminate/support": "^9.51",
         "symfony/console": "^4.0|^5.0|^6.0",
         "symfony/process": "^4.2|^5.0|^6.0"
     },

--- a/src/Concerns/InteractsWithConfiguration.php
+++ b/src/Concerns/InteractsWithConfiguration.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Laravel\Installer\Console\Concerns;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Laravel\Installer\Console\Repositories\ConfigRepository;
+
+trait InteractsWithConfiguration
+{
+    private $allowedDefault = [
+        'git',
+        'branch',
+        'organization',
+        'jet',
+        'stack',
+        'teams',
+        'pest',
+        'force',
+    ];
+
+    /**
+     * Save the default options to the laravel installer configuration file.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @return void
+     */
+    protected function saveDefaults(InputInterface $input)
+    {
+        foreach ($this->allowedDefault as $key) {
+            $this->config()->set($key, $input->getOption($key));
+        }
+    }
+
+    /**
+     * Returns an instance of the configuration repository, or a specific configuration value, if a key is passed
+     *
+     * @param  string|null  $key
+     * @return array|int|string|\Laravel\Installer\Console\Repositories\ConfigRepository
+     */
+    protected function config(string $key = null)
+    {
+        $config = new ConfigRepository();
+
+        return $key ? $config->get($key) : $config;
+    }
+}

--- a/src/ConfigureCommand.php
+++ b/src/ConfigureCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Laravel\Installer\Console;
+
+use RuntimeException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Process\Process;
+use Laravel\Installer\Console\Repositories\ConfigRepository;
+use Laravel\Installer\Console\Concerns\InteractsWithConfiguration;
+
+class ConfigureCommand extends Command
+{
+    use InteractsWithConfiguration;
+    /**
+     * Configure the command options.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('configure')
+            ->setDescription('Configure default options, for creating a new Laravel application')
+            ->addOption('git', null, InputOption::VALUE_NONE, 'Initialize a Git repository')
+            ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'The branch that should be created for a new repository')
+            ->addOption('organization', null, InputOption::VALUE_REQUIRED, 'The GitHub organization to create the new repository for')
+            ->addOption('jet', null, InputOption::VALUE_NONE, 'Installs the Laravel Jetstream scaffolding')
+            ->addOption('stack', null, InputOption::VALUE_OPTIONAL, 'The Jetstream stack that should be installed')
+            ->addOption('teams', null, InputOption::VALUE_NONE, 'Indicates whether Jetstream should be scaffolded with team support')
+            ->addOption('pest', null, InputOption::VALUE_NONE, 'Installs the Pest testing framework')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Forces install even if the directory already exists');
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->saveDefaults($input);
+
+        $output->write(PHP_EOL.'  <fg=red>Saving your defaults, for the Laravel new command</>'.PHP_EOL.PHP_EOL);
+
+        sleep(1);
+
+        return 0;
+    }
+}

--- a/src/Repositories/ConfigRepository.php
+++ b/src/Repositories/ConfigRepository.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Laravel\Installer\Console\Repositories;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\File;
+
+class ConfigRepository
+{
+    /**
+     * The path to the configuration file.
+     *
+     * @var string
+     */
+    protected $path;
+
+    /**
+     * Creates a new repository instance.
+     *
+     * @param string $path
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->path =  $_SERVER['HOME'] ?? $_SERVER['USERPROFILE'];
+
+        $this->path .= '/.laravel-installer/config.json';
+    }
+
+    /**
+     * Flush the configuration.
+     *
+     * @return $this
+     */
+    public function flush(): self
+    {
+        File::delete($this->path);
+
+        return $this;
+    }
+
+    /**
+     * Get the given configuration value.
+     *
+     * @param string $key
+     * @param mixed $default
+     *
+     * @return array|int|string
+     */
+    public function get(string $key, $default = null)
+    {
+        return Arr::get($this->all(), $key, $default);
+    }
+
+    /**
+     * Get all of the configuration items for the application.
+     */
+    public function all(): array
+    {
+        if (!is_dir(dirname($this->path))) {
+            mkdir(dirname($this->path), 0755, true);
+        }
+
+        if (file_exists($this->path)) {
+            return json_decode(file_get_contents($this->path), true);
+        }
+
+        return [];
+    }
+
+    /**
+     * Set a given configuration value.
+     *
+     * @param string $key
+     * @param array|int|string $value
+     *
+     * @return $this
+     */
+    public function set(string $key, $value): self
+    {
+        $config = $this->all();
+
+        Arr::set($config, $key, $value);
+
+        file_put_contents($this->path, json_encode($config, JSON_PRETTY_PRINT));
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Signed-off-by: Ben James <in@benjam.es>


The idea was from a tweet by Freek https://twitter.com/freekmurze/status/1623002154259587072



Where users might prefer pest as their `laravel new` default, or may want jet stream with teams on every new app

This can be done with a new configure command, or by using a `save-defaults` option on the `laravel new` command.

There is a list of saveable options. The options are saved in a config json file

Let me know if the proof of concept is worth continuing, and any suggestions for changes.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
