### PR TITLE
Add an option to install PHPUnit

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -329,7 +329,7 @@ class NewCommand extends Command
         if ($input->getOption('pest')) {
             return 'pest';
         }
-        
+
         if ($input->getOption('phpunit')) {
             return 'phpunit';
         }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -37,6 +37,7 @@ class NewCommand extends Command
             ->addOption('stack', null, InputOption::VALUE_OPTIONAL, 'The Breeze / Jetstream stack that should be installed')
             ->addOption('teams', null, InputOption::VALUE_NONE, 'Indicates whether Jetstream should be scaffolded with team support')
             ->addOption('pest', null, InputOption::VALUE_NONE, 'Installs the Pest testing framework')
+            ->addOption('phpunit', null, InputOption::VALUE_NONE, 'Installs the PHPUnit testing framework')
             ->addOption('prompt-breeze', null, InputOption::VALUE_NONE, 'Issues a prompt to determine if Breeze should be installed')
             ->addOption('prompt-jetstream', null, InputOption::VALUE_NONE, 'Issues a prompt to determine if Jetstream should be installed')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Forces install even if the directory already exists');
@@ -327,6 +328,10 @@ class NewCommand extends Command
     {
         if ($input->getOption('pest')) {
             return 'pest';
+        }
+        
+        if ($input->getOption('phpunit')) {
+            return 'phpunit';
         }
 
         $testingFrameworks = [


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

If you try to run the `laravel new --jet` command without the capability to use the interactive form, you will get an error that the testing framework is not provided. Also, adding this a mirror to the `--pest` flag. Since this is the default behavior, adding the `--pest` flag will result in the pest framework being selected.
