### PR TITLE
Prevent unknown option with git commands

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -552,6 +552,10 @@ class NewCommand extends Command
                     return $value;
                 }
 
+                if (substr($value, 0, 3) === 'git') {
+                    return $value;
+                }
+
                 return $value.' --no-ansi';
             }, $commands);
         }
@@ -559,6 +563,10 @@ class NewCommand extends Command
         if ($input->getOption('quiet')) {
             $commands = array_map(function ($value) {
                 if (substr($value, 0, 5) === 'chmod') {
+                    return $value;
+                }
+
+                if (substr($value, 0, 3) === 'git') {
                     return $value;
                 }
 


### PR DESCRIPTION
When running the `laravel new` command in certain environments, unsupported options are added to git commands.
This PR fixes that issue by excluding them just like was already done for `chmod`.