### PR TITLE
Add `--ci` option for GitHub Actions integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "require": {
         "php": "^7.3|^8.0",
         "symfony/console": "^4.0|^5.0|^6.0",
-        "symfony/process": "^4.2|^5.0|^6.0"
+        "symfony/process": "^4.2|^5.0|^6.0",
+        "symfony/filesystem": "^4.0|^5.0|^6.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.10",

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 
 class NewCommand extends Command
@@ -29,6 +30,7 @@ class NewCommand extends Command
             ->addOption('git', null, InputOption::VALUE_NONE, 'Initialize a Git repository')
             ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'The branch that should be created for a new repository', $this->defaultBranch())
             ->addOption('github', null, InputOption::VALUE_OPTIONAL, 'Create a new repository on GitHub', false)
+            ->addOption('ci', null, InputOption::VALUE_NONE, 'Include CI config for GitHub Actions')
             ->addOption('organization', null, InputOption::VALUE_REQUIRED, 'The GitHub organization to create the new repository for')
             ->addOption('breeze', null, InputOption::VALUE_NONE, 'Installs the Laravel Breeze scaffolding')
             ->addOption('dark', null, InputOption::VALUE_NONE, 'Indicate whether Breeze or Jetstream should be scaffolded with dark mode support')
@@ -166,6 +168,10 @@ class NewCommand extends Command
 
             if ($input->getOption('git') || $input->getOption('github') !== false) {
                 $this->createRepository($directory, $input, $output);
+            }
+
+            if ($input->getOption('ci') !== false) {
+                (new Filesystem)->copy(dirname(__DIR__).'/stubs/ci/github-actions.yml', $directory.'/.github/workflows/laravel.yml');
             }
 
             if ($installBreeze) {

--- a/stubs/ci/github-actions.yml
+++ b/stubs/ci/github-actions.yml
@@ -1,0 +1,49 @@
+name: Test Laravel Application
+
+on: [ push ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    env:
+      APP_ENV: testing
+      DB_CONNECTION: sqlite
+      DB_DATABASE: ":memory:"
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: composer-${{ hashFiles('composer.lock') }}
+
+      - name: Run composer install
+        run: composer install --no-progress --prefer-dist --no-interaction
+
+      - name: Prepare Laravel Application
+        run: |
+          cp .env.example .env
+          php artisan key:generate
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: npm-${{ hashFiles('package-lock.json') }}
+
+      - name: Install npm dependencies
+        run: npm install --no-progress
+
+      - name: Build assets
+        run: npm run build
+
+      - name: Run tests
+        run: php artisan test
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: Logs
+          path: ./storage/logs/*.log


### PR DESCRIPTION
This PR adds a `--ci` option which includes a fully-functioning GitHub Actions configuration to test the Laravel application with dependency caching, assets compilation and in-memory SQLite database.

I think it would be nice to have this out-of-box, at least for GitHub Actions.

*improving developer experience ✨🚀*

### Notes
Naming this option  `--ci` instead of `--github-actions` to make it extendable with other ci systems or configurations.

Some future ideas:

- `--ci=github-sqlite`
- `--ci=github-mysql`
- `--ci=gitlab-pgsql`

Thoughts?