### PR TITLE
Show the directory name at the end of the installer

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -193,9 +193,7 @@ class NewCommand extends Command
                 $output->writeln('');
             }
 
-            $output->writeln("  <bg=blue;fg=white> INFO </> Application ready in <options=bold>[{$name}]</>.".PHP_EOL);
-
-            $output->writeln('  <bg=blue;fg=white> INFO </> <options=bold>Build something amazing.</>'.PHP_EOL);
+            $output->writeln("  <bg=blue;fg=white> INFO </> Application ready in <options=bold>[{$name}]</>. Build something amazing.".PHP_EOL);
         }
 
         return $process->getExitCode();

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -193,7 +193,9 @@ class NewCommand extends Command
                 $output->writeln('');
             }
 
-            $output->writeln('  <bg=blue;fg=white> INFO </> Application ready! <options=bold>Build something amazing.</>'.PHP_EOL);
+            $output->writeln("  <bg=blue;fg=white> INFO </> Application ready in <options=bold>[{$name}]</>.".PHP_EOL);
+
+            $output->writeln('  <bg=blue;fg=white> INFO </> <options=bold>Build something amazing.</>'.PHP_EOL);
         }
 
         return $process->getExitCode();


### PR DESCRIPTION
This PR updates the final output of the installer to include the chosen directory name:

![image](https://github.com/laravel/installer/assets/4977161/5382296f-5da2-48d5-b19a-9136ec9cb2fd)

This might not be an issue for most, but I often forget the directory name I chose, especially if I switched away while the installer runs.

The Vue installer does something similar (including the name twice), but I opted not to provide the `cd` instruction because it looked a little weird on its own (we don't need to tell them to `composer install`) and developers may want to open the directory in their editor instead of "cd-ing".

![image](https://github.com/laravel/installer/assets/4977161/60e019d5-167d-4649-bdd3-384da13c683e)

I also wondered whether it could be worth adding some "Next Steps" including links to the docs on running development servers and using starter kits. Thoughts?