### PR TITLE
add option to indicate whether Breeze should be scaffolded with TypeScript support

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -37,7 +37,7 @@ class NewCommand extends Command
             ->addOption('organization', null, InputOption::VALUE_REQUIRED, 'The GitHub organization to create the new repository for')
             ->addOption('breeze', null, InputOption::VALUE_NONE, 'Installs the Laravel Breeze scaffolding')
             ->addOption('dark', null, InputOption::VALUE_NONE, 'Indicate whether Breeze or Jetstream should be scaffolded with dark mode support')
-            ->addOption('typescript', null, InputOption::VALUE_NONE, 'Indicate whether Breeze should be scaffolded with Typescript support')
+            ->addOption('typescript', null, InputOption::VALUE_NONE, 'Indicate whether Breeze should be scaffolded with Typescript support (experimental)')
             ->addOption('ssr', null, InputOption::VALUE_NONE, 'Indicate whether Breeze should be scaffolded with Inertia SSR support')
             ->addOption('jet', null, InputOption::VALUE_NONE, 'Installs the Laravel Jetstream scaffolding')
             ->addOption('stack', null, InputOption::VALUE_OPTIONAL, 'The Breeze / Jetstream stack that should be installed')
@@ -297,9 +297,9 @@ class NewCommand extends Command
             collect(multiselect(
                 label: 'Would you like any optional features?',
                 options: [
-                    'typescript' => 'Typescript',
                     'dark' => 'Dark mode',
                     'ssr' => 'Inertia SSR',
+                    'typescript' => 'Typescript (experimental)',
                 ],
                 default: array_filter([
                     $input->getOption('typescript') ? 'typescript' : null,

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -37,7 +37,7 @@ class NewCommand extends Command
             ->addOption('organization', null, InputOption::VALUE_REQUIRED, 'The GitHub organization to create the new repository for')
             ->addOption('breeze', null, InputOption::VALUE_NONE, 'Installs the Laravel Breeze scaffolding')
             ->addOption('dark', null, InputOption::VALUE_NONE, 'Indicate whether Breeze or Jetstream should be scaffolded with dark mode support')
-            ->addOption('typescript', null, InputOption::VALUE_NONE, 'Indicate whether Breeze should be scaffolded with Typescript support (experimental)')
+            ->addOption('typescript', null, InputOption::VALUE_NONE, 'Indicate whether Breeze should be scaffolded with TypeScript support (experimental)')
             ->addOption('ssr', null, InputOption::VALUE_NONE, 'Indicate whether Breeze should be scaffolded with Inertia SSR support')
             ->addOption('jet', null, InputOption::VALUE_NONE, 'Installs the Laravel Jetstream scaffolding')
             ->addOption('stack', null, InputOption::VALUE_OPTIONAL, 'The Breeze / Jetstream stack that should be installed')
@@ -299,7 +299,7 @@ class NewCommand extends Command
                 options: [
                     'dark' => 'Dark mode',
                     'ssr' => 'Inertia SSR',
-                    'typescript' => 'Typescript (experimental)',
+                    'typescript' => 'TypeScript (experimental)',
                 ],
                 default: array_filter([
                     $input->getOption('typescript') ? 'typescript' : null,

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -37,7 +37,7 @@ class NewCommand extends Command
             ->addOption('organization', null, InputOption::VALUE_REQUIRED, 'The GitHub organization to create the new repository for')
             ->addOption('breeze', null, InputOption::VALUE_NONE, 'Installs the Laravel Breeze scaffolding')
             ->addOption('dark', null, InputOption::VALUE_NONE, 'Indicate whether Breeze or Jetstream should be scaffolded with dark mode support')
-            ->addOption('typescript', null, InputOption::VALUE_NONE, 'Indicate whether Breeze should be scaffolded with TypeScript support (experimental)')
+            ->addOption('typescript', null, InputOption::VALUE_NONE, 'Indicate whether Breeze should be scaffolded with TypeScript support (Experimental)')
             ->addOption('ssr', null, InputOption::VALUE_NONE, 'Indicate whether Breeze should be scaffolded with Inertia SSR support')
             ->addOption('jet', null, InputOption::VALUE_NONE, 'Installs the Laravel Jetstream scaffolding')
             ->addOption('stack', null, InputOption::VALUE_OPTIONAL, 'The Breeze / Jetstream stack that should be installed')

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -37,6 +37,7 @@ class NewCommand extends Command
             ->addOption('organization', null, InputOption::VALUE_REQUIRED, 'The GitHub organization to create the new repository for')
             ->addOption('breeze', null, InputOption::VALUE_NONE, 'Installs the Laravel Breeze scaffolding')
             ->addOption('dark', null, InputOption::VALUE_NONE, 'Indicate whether Breeze or Jetstream should be scaffolded with dark mode support')
+            ->addOption('typescript', null, InputOption::VALUE_NONE, 'Indicate whether Breeze should be scaffolded with Typescript support')
             ->addOption('ssr', null, InputOption::VALUE_NONE, 'Indicate whether Breeze should be scaffolded with Inertia SSR support')
             ->addOption('jet', null, InputOption::VALUE_NONE, 'Installs the Laravel Jetstream scaffolding')
             ->addOption('stack', null, InputOption::VALUE_OPTIONAL, 'The Breeze / Jetstream stack that should be installed')
@@ -232,6 +233,7 @@ class NewCommand extends Command
             trim(sprintf(
                 '"'.PHP_BINARY.'" artisan breeze:install %s %s %s %s',
                 $input->getOption('stack'),
+                $input->getOption('typescript') ? '--typescript' : '',
                 $input->getOption('pest') ? '--pest' : '',
                 $input->getOption('dark') ? '--dark' : '',
                 $input->getOption('ssr') ? '--ssr' : '',
@@ -295,10 +297,12 @@ class NewCommand extends Command
             collect(multiselect(
                 label: 'Would you like any optional features?',
                 options: [
+                    'typescript' => 'Typescript',
                     'dark' => 'Dark mode',
                     'ssr' => 'Inertia SSR',
                 ],
                 default: array_filter([
+                    $input->getOption('typescript') ? 'typescript' : null,
                     $input->getOption('dark') ? 'dark' : null,
                     $input->getOption('ssr') ? 'ssr' : null,
                 ]),

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -302,9 +302,9 @@ class NewCommand extends Command
                     'typescript' => 'TypeScript (experimental)',
                 ],
                 default: array_filter([
-                    $input->getOption('typescript') ? 'typescript' : null,
                     $input->getOption('dark') ? 'dark' : null,
                     $input->getOption('ssr') ? 'ssr' : null,
+                    $input->getOption('typescript') ? 'typescript' : null,
                 ]),
             ))->each(fn ($option) => $input->setOption($option, true));
         } elseif ($input->getOption('stack') === 'blade' && ! $input->getOption('dark')) {


### PR DESCRIPTION
Add an option to indicate whether Breeze should be scaffolded with TypeScript support.
