### PR TITLE
Updated to use the Process constructor to install Pest 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": "^8.1",
+        "illuminate/support": "^10.20",
         "laravel/prompts": "^0.1",
         "symfony/console": "^6.0",
         "symfony/process": "^6.0"

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": "^8.1",
+        "illuminate/filesystem": "^10.20",
         "illuminate/support": "^10.20",
         "laravel/prompts": "^0.1",
         "symfony/console": "^6.0",

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -148,7 +148,7 @@ class NewCommand extends Command
             throw new RuntimeException('Cannot use --force option when using current directory for installation!');
         }
 
-        $composer = implode(' ', $this->composer->findComposer());
+        $composer = $this->findComposer();
 
         $commands = [
             $composer." create-project laravel/laravel \"$directory\" $version --remove-vcs --prefer-dist",
@@ -236,10 +236,8 @@ class NewCommand extends Command
      */
     protected function installBreeze(string $directory, InputInterface $input, OutputInterface $output)
     {
-        chdir($directory);
-
         $commands = array_filter([
-            $this->composer->findComposer().' require laravel/breeze',
+            $this->findComposer().' require laravel/breeze',
             trim(sprintf(
                 '"'.PHP_BINARY.'" artisan breeze:install %s %s %s %s',
                 $input->getOption('stack'),
@@ -265,10 +263,8 @@ class NewCommand extends Command
      */
     protected function installJetstream(string $directory, InputInterface $input, OutputInterface $output)
     {
-        chdir($directory);
-
         $commands = array_filter([
-            $this->composer->findComposer().' require laravel/jetstream',
+            $this->findComposer().' require laravel/jetstream',
             trim(sprintf(
                 '"'.PHP_BINARY.'" artisan jetstream:install %s %s %s %s',
                 $input->getOption('stack'),
@@ -278,7 +274,7 @@ class NewCommand extends Command
             )),
         ]);
 
-        $this->runCommands($commands, $input, $output);
+        $this->runCommands($commands, $input, $output, workingPath: $directory);
 
         $this->commitChanges('Install Jetstream', $directory, $input, $output);
     }
@@ -537,6 +533,16 @@ class NewCommand extends Command
         }
 
         return '';
+    }
+
+    /**
+     * Get the composer command for the environment.
+     *
+     * @return string
+     */
+    protected function findComposer()
+    {
+        return implode(' ', $this->composer->findComposer());
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -380,27 +380,28 @@ class NewCommand extends Command
     {
         chdir($directory);
 
-        $commands = array_filter([
-            $this->findComposer().' remove phpunit/phpunit --dev',
-            $this->findComposer().' require pestphp/pest:^2.0 pestphp/pest-plugin-laravel:^2.0 --dev',
-            '"'.PHP_BINARY.'" ./vendor/bin/pest --init',
-        ]);
+        if ($this->removeComposerPackages(['phpunit/phpunit'], $output, true)
+            && $this->requireComposerPackages(['pestphp/pest:^2.0', 'pestphp/pest-plugin-laravel:^2.0'], $output, true)) {
+            $commands = array_filter([
+                '"'.PHP_BINARY.'" ./vendor/bin/pest --init',
+            ]);
 
-        $this->runCommands($commands, $input, $output, [
-            'PEST_NO_SUPPORT' => 'true',
-        ]);
+            $this->runCommands($commands, $input, $output, [
+                'PEST_NO_SUPPORT' => 'true',
+            ]);
 
-        $this->replaceFile(
-            'pest/Feature.php',
-            $directory.'/tests/Feature/ExampleTest.php',
-        );
+            $this->replaceFile(
+                'pest/Feature.php',
+                $directory.'/tests/Feature/ExampleTest.php',
+            );
 
-        $this->replaceFile(
-            'pest/Unit.php',
-            $directory.'/tests/Unit/ExampleTest.php',
-        );
+            $this->replaceFile(
+                'pest/Unit.php',
+                $directory.'/tests/Unit/ExampleTest.php',
+            );
 
-        $this->commitChanges('Install Pest', $directory, $input, $output);
+            $this->commitChanges('Install Pest', $directory, $input, $output);
+        }
     }
 
     /**
@@ -550,6 +551,54 @@ class NewCommand extends Command
         }
 
         return 'composer';
+    }
+
+    /**
+     * Installs the given Composer Packages into the application.
+     *
+     * @return bool
+     */
+    protected function requireComposerPackages(array $packages, OutputInterface $output, bool $asDev = false)
+    {
+        $composer = $this->findComposer();
+        $command = explode(' ', $composer);
+        array_push($command, 'require');
+
+        $command = array_merge(
+            $command,
+            $packages,
+            $asDev ? ['--dev'] : [],
+        );
+
+        return 0 === (new Process($command, env: ['COMPOSER_MEMORY_LIMIT' => '-1']))
+            ->setTimeout(null)
+            ->run(function ($type, $line) use ($output) {
+                $output->write('    '.$line);
+            });
+    }
+
+    /**
+     * Removes the given Composer Packages from the application.
+     *
+     * @return bool
+     */
+    protected function removeComposerPackages(array $packages, OutputInterface $output, bool $asDev = false)
+    {
+        $composer = $this->findComposer();
+        $command = explode(' ', $composer);
+        array_push($command, 'remove');
+
+        $command = array_merge(
+            $command,
+            $packages,
+            $asDev ? ['--dev'] : [],
+        );
+
+        return 0 === (new Process($command, env: ['COMPOSER_MEMORY_LIMIT' => '-1']))
+            ->setTimeout(null)
+            ->run(function ($type, $line) use ($output) {
+                $output->write('    '.$line);
+            });
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -13,6 +13,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
+
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\select;

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -27,7 +27,7 @@ class NewCommandTest extends TestCase
 
         $tester = new CommandTester($app->find('new'));
 
-        $statusCode = $tester->execute(['name' => $scaffoldDirectoryName], ['interactive' => false]);
+        $statusCode = $tester->execute(['name' => $scaffoldDirectoryName, '--pest' => true], ['interactive' => false]);
 
         $this->assertSame(0, $statusCode);
         $this->assertDirectoryExists($scaffoldDirectory.'/vendor');


### PR DESCRIPTION
For Issue #272
Pest failed to install in Windows PowerShell when selecting no Starter Kit on the initial prompt.

+ Added two new functions from the laravel\breeze repo
  - requireComposerPackages
  - removeComposerPackages
+ Updated the `installPest` function to use `requireComposerPackages` instead
+ Now we can use the `[require/remove]ComposerPackages` functions which handle escaping commands through the Process constructor.
