### PR TITLE
Add ability to select default database connection

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -327,8 +327,8 @@ class NewCommand extends Command
             $input->setOption('stack', select(
                 label: 'Which Jetstream stack would you like to install?',
                 options: [
-                    'inertia' => 'Vue with Inertia',
                     'livewire' => 'Livewire',
+                    'inertia' => 'Vue with Inertia',
                 ]
             ));
         }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -164,7 +164,9 @@ class NewCommand extends Command
                     $directory.'/.env'
                 );
 
-                $this->configureDefaultDatabaseConnection($directory, $name);
+                $database = $this->promptForDatabaseOptions($input);
+
+                $this->configureDefaultDatabaseConnection($directory, $database, $name);
             }
 
             if ($input->getOption('git') || $input->getOption('github') !== false) {
@@ -209,22 +211,13 @@ class NewCommand extends Command
     /**
      * Configure the default database connection
      *
-     * @param  string $directory
-     * @param  string $name
+     * @param  string  $directory
+     * @param  string  $database
+     * @param  string  $name
      * @return void
      */
-    protected function configureDefaultDatabaseConnection(string $directory, string $name)
+    protected function configureDefaultDatabaseConnection(string $directory, string $database, string $name)
     {
-        $database = select(
-            label: 'Choose Database Driver',
-            options: [
-                'mysql' => 'MySQL',
-                'sqlite' => 'SQLite',
-                'pgsql' => 'PostgreSQL',
-            ],
-            default: 'mysql'
-        );
-
         $this->replaceInFile(
             'DB_CONNECTION=mysql',
             'DB_CONNECTION='.$database,
@@ -307,6 +300,31 @@ class NewCommand extends Command
         $this->runCommands($commands, $input, $output);
 
         $this->commitChanges('Install Jetstream', $directory, $input, $output);
+    }
+
+    /**
+     * Determine the default database connection.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @return void
+     */
+    protected function promptForDatabaseOptions(InputInterface $input)
+    {
+        $database = 'mysql';
+
+        if ($input->isInteractive()) {
+            $database = select(
+                label: 'Choose Database Driver',
+                options: [
+                    'mysql' => 'MySQL',
+                    'sqlite' => 'SQLite',
+                    'pgsql' => 'PostgreSQL',
+                ],
+                default: $database
+            );
+        }
+
+        return $database;
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -164,17 +164,7 @@ class NewCommand extends Command
                     $directory.'/.env'
                 );
 
-                $this->replaceInFile(
-                    'DB_DATABASE=laravel',
-                    'DB_DATABASE='.str_replace('-', '_', strtolower($name)),
-                    $directory.'/.env'
-                );
-
-                $this->replaceInFile(
-                    'DB_DATABASE=laravel',
-                    'DB_DATABASE='.str_replace('-', '_', strtolower($name)),
-                    $directory.'/.env.example'
-                );
+                $this->configureDefaultDatabaseConnection($directory, $name);
             }
 
             if ($input->getOption('git') || $input->getOption('github') !== false) {
@@ -214,6 +204,52 @@ class NewCommand extends Command
         $output = trim($process->getOutput());
 
         return $process->isSuccessful() && $output ? $output : 'main';
+    }
+
+    /**
+     * Configure the default database connection
+     *
+     * @param  string $directory
+     * @param  string $name
+     * @return void
+     */
+    protected function configureDefaultDatabaseConnection(string $directory, string $name)
+    {
+        $database = select(
+            label: 'Choose Database Driver',
+            options: [
+                'mysql' => 'MySQL',
+                'sqlite' => 'SQLite',
+                'pgsql' => 'PostgreSQL',
+            ],
+            default: 'mysql'
+        );
+
+        $this->replaceInFile(
+            'DB_CONNECTION=mysql',
+            'DB_CONNECTION='.$database,
+            $directory.'/.env'
+        );
+
+        if ($database === 'sqlite') {
+            $this->replaceInFile(
+                'DB_DATABASE=laravel',
+                '# DB_DATABASE=',
+                $directory.'/.env'
+            );
+        } else {
+            $this->replaceInFile(
+                'DB_DATABASE=laravel',
+                'DB_DATABASE='.str_replace('-', '_', strtolower($name)),
+                $directory.'/.env'
+            );
+
+            $this->replaceInFile(
+                'DB_DATABASE=laravel',
+                'DB_DATABASE='.str_replace('-', '_', strtolower($name)),
+                $directory.'/.env.example'
+            );
+        }
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -224,6 +224,14 @@ class NewCommand extends Command
             $directory.'/.env'
         );
 
+        if (! in_array($database, 'sqlite')) {
+            $this->replaceInFile(
+                'DB_CONNECTION=mysql',
+                'DB_CONNECTION='.$database,
+                $directory.'/.env.example'
+            );
+        }
+
         $defaults = [
             'DB_DATABASE=laravel',
             'DB_HOST=127.0.0.1',
@@ -241,6 +249,26 @@ class NewCommand extends Command
             );
 
             return;
+        }
+
+        $defaultPorts = [
+            'mysql' => '3306',
+            'pgsql' => '5432',
+            'sqlsrv' => '1433',
+        ];
+
+        if (isset($defaultPorts[$database])) {
+            $this->replaceInFile(
+                'DB_PORT=3306',
+                'DB_PORT='.$defaultPorts[$database],
+                $directory.'/.env'
+            );
+
+            $this->replaceInFile(
+                'DB_PORT=3306',
+                'DB_PORT='.$defaultPorts[$database],
+                $directory.'/.env.example'
+            );
         }
 
         $this->replaceInFile(
@@ -330,6 +358,7 @@ class NewCommand extends Command
                     'mysql' => 'MySQL',
                     'sqlite' => 'SQLite',
                     'pgsql' => 'PostgreSQL',
+                    'sqlsrv' => 'MSSQL',
                 ],
                 default: $database
             );

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -352,12 +352,12 @@ class NewCommand extends Command
 
         if ($input->isInteractive()) {
             $database = select(
-                label: 'Choose Database Driver',
+                label: 'Which database will your application use?',
                 options: [
                     'mysql' => 'MySQL',
-                    'sqlite' => 'SQLite',
                     'pgsql' => 'PostgreSQL',
-                    'sqlsrv' => 'MSSQL',
+                    'sqlite' => 'SQLite',
+                    'sqlsrv' => 'SQL Server',
                 ],
                 default: $database
             );

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -224,10 +224,19 @@ class NewCommand extends Command
             $directory.'/.env'
         );
 
+        $defaults = [
+            'DB_DATABASE=laravel',
+            'DB_HOST=127.0.0.1',
+            'DB_PORT=3306',
+            'DB_DATABASE=laravel',
+            'DB_USERNAME=root',
+            'DB_PASSWORD=',
+        ];
+
         if ($database === 'sqlite') {
             $this->replaceInFile(
-                'DB_DATABASE=laravel',
-                '# DB_DATABASE=',
+                $defaults,
+                collect($defaults)->map(fn ($default) => "# {$default}")->all(),
                 $directory.'/.env'
             );
         } else {
@@ -682,12 +691,12 @@ class NewCommand extends Command
     /**
      * Replace the given string in the given file.
      *
-     * @param  string  $search
-     * @param  string  $replace
+     * @param  string|array  $search
+     * @param  string|array  $replace
      * @param  string  $file
      * @return void
      */
-    protected function replaceInFile(string $search, string $replace, string $file)
+    protected function replaceInFile(string|array $search, string|array $replace, string $file)
     {
         file_put_contents(
             $file,

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -252,7 +252,6 @@ class NewCommand extends Command
         }
 
         $defaultPorts = [
-            'mysql' => '3306',
             'pgsql' => '5432',
             'sqlsrv' => '1433',
         ];

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -224,7 +224,7 @@ class NewCommand extends Command
             $directory.'/.env'
         );
 
-        if (! in_array($database, 'sqlite')) {
+        if (! in_array($database, ['sqlite'])) {
             $this->replaceInFile(
                 'DB_CONNECTION=mysql',
                 'DB_CONNECTION='.$database,

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -306,7 +306,7 @@ class NewCommand extends Command
      * Determine the default database connection.
      *
      * @param  \Symfony\Component\Console\Input\InputInterface  $input
-     * @return void
+     * @return string
      */
     protected function promptForDatabaseOptions(InputInterface $input)
     {

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -239,19 +239,21 @@ class NewCommand extends Command
                 collect($defaults)->map(fn ($default) => "# {$default}")->all(),
                 $directory.'/.env'
             );
-        } else {
-            $this->replaceInFile(
-                'DB_DATABASE=laravel',
-                'DB_DATABASE='.str_replace('-', '_', strtolower($name)),
-                $directory.'/.env'
-            );
 
-            $this->replaceInFile(
-                'DB_DATABASE=laravel',
-                'DB_DATABASE='.str_replace('-', '_', strtolower($name)),
-                $directory.'/.env.example'
-            );
+            return;
         }
+
+        $this->replaceInFile(
+            'DB_DATABASE=laravel',
+            'DB_DATABASE='.str_replace('-', '_', strtolower($name)),
+            $directory.'/.env'
+        );
+
+        $this->replaceInFile(
+            'DB_DATABASE=laravel',
+            'DB_DATABASE='.str_replace('-', '_', strtolower($name)),
+            $directory.'/.env.example'
+        );
     }
 
     /**


### PR DESCRIPTION
* Allow selecting `sqlite`, `mysql` or `pgsql` driver using Laravel Prompts
* Default to `mysql` if accessed via `--no-interaction`.
* Update `DB_CONNECTION` to the correct database driver. (SQLite database doesn't update `.env.example`)
* Comment other `DB_*` variables when using `sqlite`.
* Update `DB_PORT` value based on selected database driver.

