### PR TITLE
Use prompts non-interactive mode instead of Symfony fallbacks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^8.1",
         "illuminate/filesystem": "^10.20",
         "illuminate/support": "^10.20",
-        "laravel/prompts": "^0.1",
+        "laravel/prompts": "^0.1.9",
         "symfony/console": "^6.0",
         "symfony/process": "^6.0"
     },

--- a/src/Concerns/ConfiguresPrompts.php
+++ b/src/Concerns/ConfiguresPrompts.php
@@ -25,7 +25,9 @@ trait ConfiguresPrompts
      */
     protected function configurePrompts(InputInterface $input, OutputInterface $output)
     {
-        Prompt::fallbackWhen(! $input->isInteractive() || PHP_OS_FAMILY === 'Windows');
+        Prompt::interactive($input->isInteractive() && stream_isatty(STDIN));
+
+        Prompt::fallbackWhen(PHP_OS_FAMILY === 'Windows');
 
         TextPrompt::fallbackUsing(fn (TextPrompt $prompt) => $this->promptUntilValid(
             fn () => (new SymfonyStyle($input, $output))->ask($prompt->label, $prompt->default ?: null) ?? '',


### PR DESCRIPTION
This PR updates the Laravel installer to use Prompts' new "non-interactive mode" instead of relying on the Symfony fallback.

This does not change the behaviour when using the `-n` argument, as the command will never call the `interact` hook, which is the only place we currently use Prompts in the installer. It only changes the output when there are missing required arguments and the input is not a TTY (such as in CI).

|Before|After|
|-|-|
|![image](https://github.com/laravel/installer/assets/4977161/d5558fd0-58bd-47f0-bf21-28ce98860be9)|![image](https://github.com/laravel/installer/assets/4977161/f63e81a4-0dbc-4936-a423-b14767d0c6be)|

This change is pretty insignificant for the installer, but it paves the way for https://github.com/laravel/prompts/pull/57, allowing us to remove the fallback code from this repo and any other packages/projects that can't or don't rely on `laravel/framework` to configure a Windows fallback.