### PR TITLE
Remove extra DB_DATABASE

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -248,7 +248,6 @@ class NewCommand extends Command
         }
 
         $defaults = [
-            'DB_DATABASE=laravel',
             'DB_HOST=127.0.0.1',
             'DB_PORT=3306',
             'DB_DATABASE=laravel',


### PR DESCRIPTION
When creating a new Laravel project using the installer, and selecting sqlite as database the .env file `DB_DATABASE` row ends up being commented out twice:
```
# DB_PORT=3306
# # DB_DATABASE=laravel
# DB_USERNAME=root
```

This PR fixes that by removing the extra line in `$defaults`