### PR TITLE
Apply using the str_starts_with function

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -699,11 +699,11 @@ class NewCommand extends Command
     {
         if (! $output->isDecorated()) {
             $commands = array_map(function ($value) {
-                if (substr($value, 0, 5) === 'chmod') {
+                if (str_starts_with($value, 'chmod')) {
                     return $value;
                 }
 
-                if (substr($value, 0, 3) === 'git') {
+                if (str_starts_with($value, 'git')) {
                     return $value;
                 }
 
@@ -713,11 +713,11 @@ class NewCommand extends Command
 
         if ($input->getOption('quiet')) {
             $commands = array_map(function ($value) {
-                if (substr($value, 0, 5) === 'chmod') {
+                if (str_starts_with($value, 'chmod')) {
                     return $value;
                 }
 
-                if (substr($value, 0, 3) === 'git') {
+                if (str_starts_with($value, 'git')) {
                     return $value;
                 }
 


### PR DESCRIPTION
# Changed log

- It should be good to use the `str_starts_with` function to check the specific first sub-string.
- According to the [reference](https://www.php.net/manual/en/function.str-starts-with.php), the feature is available since the PHP 8 version is released.