### PR TITLE
Add mariadb installation option

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -661,7 +661,7 @@ class NewCommand extends Command
     protected function getVersion(InputInterface $input)
     {
         if ($input->getOption('dev')) {
-            return 'dev-master';
+            return 'dev-slim-skeleton-11.x';
         }
 
         return '';

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -233,6 +233,11 @@ class NewCommand extends Command
      */
     protected function configureDefaultDatabaseConnection(string $directory, string $database, string $name)
     {
+        // MariaDB Configuration only exists as of Laravel 11
+        if ($database === 'mariadb' && ! $this->hasMariaDBConfig($directory)) {
+            $database = 'mysql';
+        }
+
         $this->replaceInFile(
             'DB_CONNECTION=mysql',
             'DB_CONNECTION='.$database,
@@ -294,6 +299,26 @@ class NewCommand extends Command
             'DB_DATABASE=laravel',
             'DB_DATABASE='.str_replace('-', '_', strtolower($name)),
             $directory.'/.env.example'
+        );
+    }
+
+    /**
+     * Determine if the application has a MariaDB configuration.
+     *
+     * @param  string  $directory
+     * @return bool
+     */
+    protected function hasMariaDBConfig(string $directory): bool
+    {
+        // Laravel 11+ has moved the config files into the framework and there exists the mariadb configuration
+        if (! file_exists($directory.'/config/database.php')) {
+            return true;
+        }
+
+        // Check if for whatever reasons there exists a mariadb configuration in the database config
+        return str_contains(
+            file_get_contents($directory.'/config/database.php'),
+            "'mariadb' =>"
         );
     }
 
@@ -368,6 +393,7 @@ class NewCommand extends Command
                 label: 'Which database will your application use?',
                 options: [
                     'mysql' => 'MySQL',
+                    'mariadb' => 'MariaDB',
                     'pgsql' => 'PostgreSQL',
                     'sqlite' => 'SQLite',
                     'sqlsrv' => 'SQL Server',

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -233,7 +233,7 @@ class NewCommand extends Command
      */
     protected function configureDefaultDatabaseConnection(string $directory, string $database, string $name)
     {
-        // MariaDB Configuration only exists as of Laravel 11
+        // MariaDB configuration only exists as of Laravel 11...
         if ($database === 'mariadb' && ! $this->hasMariaDBConfig($directory)) {
             $database = 'mysql';
         }
@@ -310,12 +310,11 @@ class NewCommand extends Command
      */
     protected function hasMariaDBConfig(string $directory): bool
     {
-        // Laravel 11+ has moved the config files into the framework and there exists the mariadb configuration
+        // Laravel 11+ has moved the configuration files into the framework... which contains the MariaDB configuration entry...
         if (! file_exists($directory.'/config/database.php')) {
             return true;
         }
 
-        // Check if for whatever reasons there exists a mariadb configuration in the database config
         return str_contains(
             file_get_contents($directory.'/config/database.php'),
             "'mariadb' =>"

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -303,7 +303,7 @@ class NewCommand extends Command
     }
 
     /**
-     * Determine if the application has a MariaDB configuration.
+     * Determine if the application has a MariaDB configuration entry.
      *
      * @param  string  $directory
      * @return bool

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -661,7 +661,7 @@ class NewCommand extends Command
     protected function getVersion(InputInterface $input)
     {
         if ($input->getOption('dev')) {
-            return 'dev-slim-skeleton-11.x';
+            return 'dev-master';
         }
 
         return '';

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -310,7 +310,7 @@ class NewCommand extends Command
      */
     protected function hasMariaDBConfig(string $directory): bool
     {
-        // Laravel 11+ has moved the configuration files into the framework... which contains the MariaDB configuration entry...
+        // Laravel 11+ has moved the configuration files into the framework...
         if (! file_exists($directory.'/config/database.php')) {
             return true;
         }


### PR DESCRIPTION
Laravel 11 will support a new Maria DB Configuration in `config/database.php` (due to slimming the skeleton this will be moved to the framework).

A developer should be able to select the option `mariadb` during installation. Which will fallback to `mysql` in Laravel 10 and will use the `mariadb` configuration in Laravel 11.

~Note: This PR will be draft until the slimmed skeleton is merged. Because the Slimmed skeleton branch is not working, I can not verify if everything works as intended.~

Works on the master branch and the 10.x branch

Tested as follows:
Replace the file in `~/.composer/vendor/laravel/installer/src/NewCommand.php`
Run `laravel new l11 --dev` and select database mariadb => `.env` should contain mariadb
Run `laravel new l10` and select database mariadb => `.env` should contain mysql