### PR TITLE
[6.x] Adds `alias` to `6.x-dev`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.x-dev"
+            "dev-master": "6.x-dev"
         }
     },
     "config": {


### PR DESCRIPTION
This pull request adds an `alias` to 6.x.