### PR TITLE
[develop] Adds Laravel 11 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2, 8.3]
+        php: [8.2, 8.3]
 
     name: PHP ${{ matrix.php }}
 

--- a/composer.json
+++ b/composer.json
@@ -10,16 +10,16 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "illuminate/filesystem": "^10.20",
-        "illuminate/support": "^10.20",
+        "php": "^8.2",
+        "illuminate/filesystem": "^11.0",
+        "illuminate/support": "^11.0",
         "laravel/prompts": "^0.1",
-        "symfony/console": "^6.0",
-        "symfony/process": "^6.0"
+        "symfony/console": "^7.0",
+        "symfony/process": "^7.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^9.3"
+        "phpunit/phpunit": "^10.4"
     },
     "bin": [
         "bin/laravel"

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.x-dev"
+            "dev-master": "6.x-dev"
         }
     },
     "config": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,4 @@
             <exclude>./tests/scaffolds</exclude>
         </testsuite>
     </testsuites>
-    <php>
-        <env name="APP_KEY" value="base64:uz4B1RtFO57QGzbZX1kRYX9hIRB50+QzqFeg9zbFJlY="/>
-    </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         beStrictAboutTestsThatDoNotTestAnything="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertDeprecationsToExceptions="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnError="false"
-         stopOnFailure="false"
-         verbose="true"
->
+<phpunit colors="true">
     <testsuites>
         <testsuite name="Laravel Installer Test Suite">
             <directory suffix="Test.php">./tests</directory>
             <exclude>./tests/scaffolds</exclude>
         </testsuite>
     </testsuites>
+    <php>
+        <env name="APP_KEY" value="base64:uz4B1RtFO57QGzbZX1kRYX9hIRB50+QzqFeg9zbFJlY="/>
+    </php>
 </phpunit>

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -133,7 +133,7 @@ class NewCommand extends Command
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->validateStackOption($input);
 


### PR DESCRIPTION
This pull request adds Laravel 11 support to the installer and is awaiting the completion of the starter kits - this will allow for testing with their respective major versions.