### PR TITLE
[5.x] Added default value on selection question while creating new application

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -101,6 +101,7 @@ class NewCommand extends Command
                     'breeze' => 'Laravel Breeze',
                     'jetstream' => 'Laravel Jetstream',
                 ],
+                default: 'none',
             )) {
                 'breeze' => $input->setOption('breeze', true),
                 'jetstream' => $input->setOption('jet', true),
@@ -118,6 +119,7 @@ class NewCommand extends Command
             $input->setOption('pest', select(
                 label: 'Which testing framework do you prefer?',
                 options: ['PHPUnit', 'Pest'],
+                default: 'PHPUnit',
             ) === 'Pest');
         }
 
@@ -422,7 +424,8 @@ class NewCommand extends Command
                     'react' => 'React with Inertia',
                     'vue' => 'Vue with Inertia',
                     'api' => 'API only',
-                ]
+                ],
+                default: 'blade',
             ));
         }
 
@@ -462,7 +465,8 @@ class NewCommand extends Command
                 options: [
                     'livewire' => 'Livewire',
                     'inertia' => 'Vue with Inertia',
-                ]
+                ],
+                default: 'livewire',
             ));
         }
 


### PR DESCRIPTION
This pull request aims to enhance the Laravel installer by introducing default values for selection questions during the process of creating a new application. The addition of default values streamlines the installation process, making it more user-friendly and efficient.

With this update, I've implemented default values for certain selection questions that users encounter while creating a new Laravel application. These defaults are thoughtfully chosen to align with best practices and common preferences, ensuring a smoother on-boarding experience for both new and experienced users.

By providing default values, users can simply accept the pre-filled options if they align with their requirements. This significantly reduces the number of manual inputs, making the installation process faster and more straightforward.