### PR TITLE
[develop] Keeps supporting older illuminate components

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,6 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist
         run: |
           composer require "laravel/framework=^${{ matrix.laravel }}" --no-update
           composer update --prefer-dist --no-interaction --no-progress

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,9 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.2, 8.3]
+        laravel: [10, 11]
 
-    name: PHP ${{ matrix.php }}
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 
     steps:
       - name: Checkout code
@@ -34,6 +35,9 @@ jobs:
 
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist
+        run: |
+          composer require "laravel/framework=^${{ matrix.laravel }}" --no-update
+          composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
         run: vendor/bin/phpunit
@@ -45,8 +49,9 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.2, 8.3]
+        laravel: [10, 11]
 
-    name: PHP ${{ matrix.php }} - Windows
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Windows
 
     steps:
       - name: Set git to use LF
@@ -67,7 +72,9 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist
+        run: |
+          composer require "laravel/framework=^${{ matrix.laravel }}" --no-update
+          composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework=^${{ matrix.laravel }}" --no-update
+          composer require "laravel/framework=~${{ matrix.laravel }}" --no-update
           composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/filesystem": "^11.0",
-        "illuminate/support": "^11.0",
+        "illuminate/filesystem": "^10.20|^11.0",
+        "illuminate/support": "^10.20|^11.0",
         "laravel/prompts": "^0.1",
-        "symfony/console": "^7.0",
-        "symfony/process": "^7.0"
+        "symfony/console": "^6.2|^7.0",
+        "symfony/process": "^6.2|^7.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.10",


### PR DESCRIPTION
This pull request allows the usage of Symfony 6 components while keeping supporting Symfony 7 components.