### PR TITLE
[5.x] Improves ending message

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -209,7 +209,14 @@ class NewCommand extends Command
                 $output->writeln('');
             }
 
-            $output->writeln("  <bg=blue;fg=white> INFO </> Application ready in <options=bold>[{$name}]</>. Build something amazing.".PHP_EOL);
+            $output->writeln("  <bg=blue;fg=white> INFO </> Application ready in <options=bold>[{$name}]</>. You may start your local development using:".PHP_EOL);
+
+            $output->writeln('<fg=gray>➜</> <options=bold>cd '.$name.'</>');
+            $output->writeln('<fg=gray>➜</> <options=bold>php artisan serve</>');
+            $output->writeln('');
+
+            $output->writeln('  New to Laravel? Check out our <href=https://bootcamp.laravel.com>bootcamp</> and <href=https://laravel.com/docs/installation#next-steps>documentation</>. <options=bold>Build something amazing!</>');
+            $output->writeln('');
         }
 
         return $process->getExitCode();


### PR DESCRIPTION
This pull request improves the ending message:

// before
<img width="699" alt="before" src="https://github.com/laravel/installer/assets/5457236/e518eee0-0a93-4cd3-a817-b7cad337c640">

// after
<img width="1038" alt="Screenshot 2024-01-23 at 16 16 58" src="https://github.com/laravel/installer/assets/5457236/cee95871-b04e-42a5-a032-0fdcd8ec60f2">
