### PR TITLE
Check for latest version

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -843,7 +843,7 @@ class NewCommand extends Command
             $output->write('    '.$line);
         });
 
-        if($this->existsNewerInstallerVersion()) {
+        if ($this->existsNewerInstallerVersion()) {
             $output->writeln('  <bg=green;fg=white> NEW VERSION </> A newer version of Laravel Installer is available. To update simply run <options=bold>`composer global update`</>'.PHP_EOL);
         }
 
@@ -911,7 +911,7 @@ class NewCommand extends Command
     }
 
     /**
-     * Get latest version without leading "v"
+     * Get latest version without leading "v".
      */
     protected function getLatestVersion(): string
     {
@@ -919,7 +919,7 @@ class NewCommand extends Command
 
         $tag = $latestRelease['tag_name'];
 
-        if(str_starts_with($tag, 'v')) {
+        if (str_starts_with($tag, 'v')) {
             $tag = substr($tag, 1);
         }
 
@@ -927,7 +927,7 @@ class NewCommand extends Command
     }
 
     /**
-     * Get latest release information
+     * Get latest release information.
      */
     protected function getLatestRelease(): array
     {

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -82,6 +82,36 @@ class NewCommand extends Command
   | |___| (_| | | | (_| |\ V /  __/ |
   |______\__,_|_|  \__,_| \_/ \___|_|</>'.PHP_EOL.PHP_EOL);
 
+        if ($this->existsNewerInstallerVersion()) {
+            $output->writeln(PHP_EOL.'  <bg=green;fg=white> NEW VERSION </> A newer version of Laravel Installer is available.'.PHP_EOL);
+
+            $shouldUpdate = select(
+                label: 'Do you want to update your Laravel Installer before continuing?',
+                options: [
+                    'yes' => 'Yes, please update the Laravel Installer',
+                    'no' => 'No, continue with the current version',
+                ],
+                default: 'yes',
+            );
+
+            if ($shouldUpdate === 'yes') {
+
+                $this->composer = new Composer(new Filesystem());
+
+                $output->writeln('  <bg=green;fg=white> NEW VERSION </> Updating Laravel Installer...'.PHP_EOL);
+
+                $this->runCommands([
+                    $this->findComposer().' global update laravel/installer',
+                ], $input, $output);
+
+                $output->writeln(PHP_EOL.'  <bg=green;fg=white> NEW VERSION </> The Laravel Installer was sucessfully updated.'.PHP_EOL);
+
+                $output->writeln('  <fg=gray>➜</> Please run <options=bold>laravel new</> again.'.PHP_EOL);
+
+                exit(0);
+            }
+        }
+
         if (! $input->getArgument('name')) {
             $input->setArgument('name', text(
                 label: 'What is the name of your project?',
@@ -842,10 +872,6 @@ class NewCommand extends Command
         $process->run(function ($type, $line) use ($output) {
             $output->write('    '.$line);
         });
-
-        if ($this->existsNewerInstallerVersion()) {
-            $output->writeln('  <bg=green;fg=white> NEW VERSION </> A newer version of Laravel Installer is available. To update simply run <options=bold>`composer global update`</>'.PHP_EOL);
-        }
 
         return $process;
     }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -95,7 +95,6 @@ class NewCommand extends Command
             );
 
             if ($shouldUpdate === 'yes') {
-
                 $this->composer = new Composer(new Filesystem());
 
                 $output->writeln('  <bg=green;fg=white> NEW VERSION </> Updating Laravel Installer...'.PHP_EOL);


### PR DESCRIPTION
Closes #306 

This prompts the user to update the Laravel Installer before continuing.

How it looks like when the update will be installed (composer messages are wrong because the Laravel Installer Version was changed manually, and therefor Composer does not update anything)

<img width="500" alt="Screenshot 2024-01-25 at 10 40 03" src="https://github.com/laravel/installer/assets/15707543/a4b17077-1ff0-4581-a730-ca9663e979dd">

How it looks like when you continue:

<img width="500" alt="Screenshot 2024-01-25 at 10 40 24" src="https://github.com/laravel/installer/assets/15707543/7b879a71-7595-4633-bfb3-39ea9b187d56">

To test this you can to the following:

0. Make sure Laravel Installer is up to date with `composer global update`
1. Copy the content of `src/NewCommand.php` in this PR
2. Paste it into `~/.composer/vendor/laravel/installer/src/NewCommand.php` 
3. Change the version in `~/.composer/vendor/laravel/installer/bin/laravel` into `5.3.0`
4. Run `laravel new test --no-interaction`

To test if the check is not run, you can simply change the version back to `5.4.0`.


### Considerations

There is also the question how you want to handle downtime with Github. Probably then assuming you are on the latest version?