### PR TITLE
[5.x] Fixes Pest installation on Windows

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -598,7 +598,7 @@ class NewCommand extends Command
 
         $commands = [
             $composerBinary.' remove phpunit/phpunit --dev --no-update',
-            $composerBinary.' require pestphp/pest:^2.0 pestphp/pest-plugin-laravel:^2.0 --no-update --dev',
+            $composerBinary.' require pestphp/pest pestphp/pest-plugin-laravel --no-update --dev',
             $composerBinary.' update',
             $this->phpBinary().' ./vendor/bin/pest --init',
         ];


### PR DESCRIPTION
Fixes https://github.com/laravel/installer/issues/313.

This pull request fixes the usage of the caret (^) as that char is not supported on Windows shells. The fix is simply not be explicit about the version, as we don't even need to be explicit.