### PR TITLE
Enhanced installation adding configurable database conncetion prompts

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -16,9 +16,9 @@ use Symfony\Component\Process\Process;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\multiselect;
+use function Laravel\Prompts\password;
 use function Laravel\Prompts\select;
 use function Laravel\Prompts\text;
-use function Laravel\Prompts\password;
 
 class NewCommand extends Command
 {
@@ -249,7 +249,7 @@ class NewCommand extends Command
      * @param  string  $name
      * @return void
      */
-    protected function configureDefaultDatabaseConnection(string $directory, string $database, string $name, array | bool $config)
+    protected function configureDefaultDatabaseConnection(string $directory, string $database, string $name, array|bool $config)
     {
         $this->pregReplaceInFile(
             '/DB_CONNECTION=.*/',
@@ -292,7 +292,7 @@ class NewCommand extends Command
             'sqlsrv' => '1433',
         ];
 
-        $defaults = collect($defaults)->map(fn ($default) => explode('=', $default))->pluck(1,0)->all();
+        $defaults = collect($defaults)->map(fn ($default) => explode('=', $default))->pluck(1, 0)->all();
 
         if (! $config) {
             if (isset($defaultPorts[$database])) {


### PR DESCRIPTION
Problem: Fresh installation of laravel using any database driver rather than sqlite starts with an error of can't connect with database. (more information ar #324)

Description:
This PR is supposed to make laravel installation smoother and more user-friendly by removing unnecessary migration prompt when database connection is not specified for drivers rather than mysql.

![laravel-installer-windows](https://github.com/laravel/installer/assets/81873266/91102bef-fc99-470d-b650-21e00d3bb111)

### **Here's a video comparing current installer and patched installer experience ** 

- **windows**

https://github.com/laravel/installer/assets/81873266/63ea5039-c76e-444b-a953-3afa6cb32e81

- **Linux**

https://github.com/laravel/installer/assets/81873266/0e47ecbc-9ec3-4392-97ab-35e1221927c0

Also, 
The migration prompt won't appear when database connection is not specified.


Changes Made:

- Added new `promptForDatabaseConfig` function to specify the database connection.
- The prompt is made compatible with command option such as **--database=pgsql**
- **promptForDatabaseOptions** now returns three array values including **configuration array**
- Moved Default connection information array from `commentDatabaseConfigurationForSqlite` to **configureDefaultDatabaseConnection**

Any feedback & suggestions will be appreciated. Thank You.