### PR TITLE
Update `APP_URL` to end in `.localhost`

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -722,7 +722,7 @@ class NewCommand extends Command
      */
     protected function generateAppUrl($name)
     {
-        $hostname = mb_strtolower($name).'.test';
+        $hostname = mb_strtolower($name).'.localhost';
 
         return $this->canResolveHostname($hostname) ? 'http://'.$hostname : 'http://localhost';
     }


### PR DESCRIPTION
While `.test` is convenient for developers using Laravel Valet, it provides an obstacle for users that don't. PR #240 improved this problem by first checking that the domain resolves correctly. My PR should improve this even further by not requiring DNS modifications for users that aren't using Valet while still allowing them to use `my-app-name.localhost`.

According to the [W3 specification](https://www.w3.org/TR/secure-contexts/#localhost), domains ending in `.localhost` are intended to be treated specially, only resolving as loopback addresses. This means using `.localhost` will allow the browser to treat the site as a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts), allowing developers to use features that would normally require HTTPS (such as the Geolocation API).

This does not break existing features because it only applies to new installations as well as keeps the `canResolveHostname` check with fallback to `http://localhost` in case the DNS resolution fails. In addition, developers using Valet can still use either `.test` or `.localhost`.

