### PR TITLE
Prevent using unavailable databases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, fileinfo, pdo, pdo_sqlsrv,
+          extensions: dom, curl, libxml, mbstring, zip, fileinfo, sqlsrv, pdo, pdo_sqlsrv,
           ini-values: error_reporting=E_ALL, memory_limit=512M
           tools: composer:v2
           coverage: none

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,15 +44,6 @@ jobs:
   windows_tests:
     runs-on: windows-latest
 
-    services:
-      sqlsrv:
-        image: mcr.microsoft.com/mssql/server:2019-latest
-        env:
-          ACCEPT_EULA: Y
-          SA_PASSWORD: Forge123
-        ports:
-          - 1433:1433
-
     strategy:
       fail-fast: true
       matrix:
@@ -74,7 +65,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, fileinfo, sqlsrv, pdo, pdo_sqlsrv,
+          extensions: dom, curl, libxml, mbstring, zip, fileinfo, pdo, pdo_sqlsrv,
           ini-values: error_reporting=E_ALL, memory_limit=512M
           tools: composer:v2
           coverage: none

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, fileinfo, sqlsrv, pdo, pdo_sqlsrv,
+          extensions: dom, curl, libxml, mbstring, zip, fileinfo, sqlsrv, pdo, pdo_sqlsrv
           ini-values: error_reporting=E_ALL, memory_limit=512M
           tools: composer:v2
           coverage: none

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, fileinfo
+          extensions: dom, curl, libxml, mbstring, zip, fileinfo, sqlsrv, pdo, pdo_sqlsrv,
           ini-values: error_reporting=E_ALL, memory_limit=512M
           tools: composer:v2
           coverage: none

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,15 @@ jobs:
   windows_tests:
     runs-on: windows-latest
 
+    services:
+      sqlsrv:
+        image: mcr.microsoft.com/mssql/server:2019-latest
+        env:
+          ACCEPT_EULA: Y
+          SA_PASSWORD: Forge123
+        ports:
+          - 1433:1433
+
     strategy:
       fail-fast: true
       matrix:

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -448,13 +448,9 @@ class NewCommand extends Command
      */
     protected function promptForDatabaseOptions(string $directory, InputInterface $input)
     {
-        $databaseOptions = $this->databaseOptions();
-
-        if (empty($databaseOptions)) {
-            throw new RuntimeException('No database drivers are available. Please ensure the required PHP extensions are installed.');
-        }
-
-        $defaultDatabase = collect($databaseOptions)->keys()->first();
+        $defaultDatabase = collect(
+            $databaseOptions = $this->databaseOptions()
+        )->keys()->first();
 
         if (! $input->getOption('database') && $input->isInteractive()) {
             $input->setOption('database', select(
@@ -475,7 +471,7 @@ class NewCommand extends Command
     }
 
     /**
-     * Return the available database options.
+     * Return the database options.
      *
      * @return array
      */
@@ -488,8 +484,8 @@ class NewCommand extends Command
             'mariadb' => 'MariaDB',
             'pgsql' => 'PostgreSQL',
             'sqlsrv' => 'SQL Server',
-        ])->filter(function ($label, $type) {
-            return match ($type) {
+        ])->map(function ($label, $type) {
+            $result = match ($type) {
                 'mysql',
                 'mariadb' => extension_loaded('pdo_mysql'),
                 'pgsql' => extension_loaded('pdo_pgsql'),
@@ -497,6 +493,8 @@ class NewCommand extends Command
                 'sqlsrv' => extension_loaded('pdo_sqlsrv'),
                 default => false,
             };
+
+            return $result ? $label : "$label (Missing PDO extension)";
         })->all();
     }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -457,9 +457,6 @@ class NewCommand extends Command
                 label: 'Which database will your application use?',
                 options: $databaseOptions,
                 default: $defaultDatabase,
-                validate: fn (string $engine) => ! $this->isDatabaseEngineAvailable($engine)
-                    ? 'You selected an engine with a missing PDO extension. Please select an available option.'
-                    : null
             ));
 
             if ($input->getOption('database') !== $defaultDatabase) {

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -471,7 +471,7 @@ class NewCommand extends Command
     }
 
     /**
-     * Return the database options.
+     * Get the available database options.
      *
      * @return array
      */

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -473,9 +473,9 @@ class NewCommand extends Command
     /**
      * Return the database options.
      *
-     * @return \Illuminate\Support\Collection
+     * @return array
      */
-    public function databaseOptions(): Collection
+    public function databaseOptions(): array
     {
         return collect([
             'sqlite' => ['SQLite', extension_loaded('pdo_sqlite')],
@@ -485,7 +485,8 @@ class NewCommand extends Command
             'sqlsrv' => ['SQL Server', extension_loaded('pdo_sqlsrv')],
         ])
             ->sortBy(fn ($database) => $database[1] ? 0 : 1)
-            ->map(fn ($database) => $database[0].($database[1] ? '' : ' (Missing PDO extension)'));
+            ->map(fn ($database) => $database[0].($database[1] ? '' : ' (Missing PDO extension)'))
+            ->all();
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -475,7 +475,7 @@ class NewCommand extends Command
      *
      * @return array
      */
-    public function databaseOptions(): array
+    protected function databaseOptions(): array
     {
         return collect([
             'sqlite' => ['SQLite', extension_loaded('pdo_sqlite')],

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -459,7 +459,7 @@ class NewCommand extends Command
                 default: $defaultDatabase,
             ));
 
-            if ($input->getOption('database') !== $defaultDatabase) {
+            if ($input->getOption('database') !== 'sqlite') {
                 $migrate = confirm(
                     label: 'Default database updated. Would you like to run the default database migrations?',
                     default: true

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -473,40 +473,19 @@ class NewCommand extends Command
     /**
      * Return the database options.
      *
-     * @return array
+     * @return \Illuminate\Support\Collection
      */
-    public function databaseOptions(): array
+    public function databaseOptions(): Collection
     {
         return collect([
-            // Sequence is that of the default selected database option.
-            'sqlite' => 'SQLite',
-            'mysql' => 'MySQL',
-            'mariadb' => 'MariaDB',
-            'pgsql' => 'PostgreSQL',
-            'sqlsrv' => 'SQL Server',
-        ])->map(function ($label, $engine) {
-            return $this->isDatabaseEngineAvailable($engine)
-                ? $label
-                : "$label (Missing PDO extension)";
-        })->all();
-    }
-
-    /**
-     * Determine if the given database engine is available.
-     *
-     * @param  string  $engine
-     * @return bool
-     */
-    public function isDatabaseEngineAvailable(string $engine): bool
-    {
-        return match ($engine) {
-            'mysql',
-            'mariadb' => extension_loaded('pdo_mysql'),
-            'pgsql' => extension_loaded('pdo_pgsql'),
-            'sqlite' => extension_loaded('pdo_sqlite'),
-            'sqlsrv' => extension_loaded('pdo_sqlsrv'),
-            default => false,
-        };
+            'sqlite' => ['SQLite', extension_loaded('pdo_sqlite')],
+            'mysql' => ['MySQL', extension_loaded('pdo_mysql')],
+            'mariadb' => ['MariaDB', extension_loaded('pdo_mysql')],
+            'pgsql' => ['PostgreSQL', extension_loaded('pdo_pgsql')],
+            'sqlsrv' => ['SQL Server', extension_loaded('pdo_sqlsrv')],
+        ])
+            ->sortBy(fn ($database) => $database[1] ? 0 : 1)
+            ->map(fn ($database) => $database[0].($database[1] ? '' : ' (Missing PDO extension)'));
     }
 
     /**


### PR DESCRIPTION
~This PR will make sure that unavailable database options are filtered out of the database list. In some rare situations, Sqlite isn't available and people fail their installations because they press continue on it as the default. This PR will filter out Sqlite when it's not available as a PDO driver and will move to the next in line as the default. Similar, SqlServer is filtered out on macOS, etc.~

Pending https://github.com/shivammathur/setup-php/discussions/835