### PR TITLE
Only run migration after selecting the database

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -158,9 +158,12 @@ class NewCommand extends Command
         }
 
         $composer = $this->findComposer();
+        $phpBinary = $this->phpBinary();
 
         $commands = [
-            $composer." create-project laravel/laravel \"$directory\" $version --remove-vcs --prefer-dist",
+            $composer." create-project laravel/laravel \"$directory\" $version --remove-vcs --prefer-dist --no-scripts",
+            $composer." run post-root-package-install -d \"$directory\"",
+            $phpBinary." \"$directory/artisan\" key:generate --ansi",
         ];
 
         if ($directory != '.' && $input->getOption('force')) {
@@ -464,12 +467,12 @@ class NewCommand extends Command
                 default: $defaultDatabase,
             ));
 
-            if ($input->getOption('database') !== 'sqlite') {
-                $migrate = confirm(
-                    label: 'Default database updated. Would you like to run the default database migrations?',
-                    default: true
-                );
-            }
+            $migrate = confirm(
+                label: $input->getOption('database') !== 'sqlite'
+                    ? 'Default database updated. Would you like to run the default database migrations?'
+                    : 'Would you like to run the default database migrations?',
+                default: true
+            );
         }
 
         return [$input->getOption('database') ?? $defaultDatabase, $migrate ?? false];


### PR DESCRIPTION
### Before

`composer.json` from `laravel/laravel` will create `database/database.sqlite` and run `php artisan migrate` before we even select the default database.

![image](https://github.com/laravel/framework/assets/52510455/cdb70c8f-199f-4053-8f0b-860f4db963c7)

### After

1. Disable scripts during `composer create-project` to avoid above scenario.
2. Run `composer run post-root-package-install` to copy `.env.example` to `.env`.
3. Run `php artisan key:generate`
4. Select the correct database using prompt.
5. Run migration

https://github.com/laravel/installer/assets/172966/443d4447-8ebc-474f-9f52-2d5adc00cb5d


