### PR TITLE
Add `no-migrate` option

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -47,6 +47,7 @@ class NewCommand extends Command
             ->addOption('github', null, InputOption::VALUE_OPTIONAL, 'Create a new repository on GitHub', false)
             ->addOption('organization', null, InputOption::VALUE_REQUIRED, 'The GitHub organization to create the new repository for')
             ->addOption('database', null, InputOption::VALUE_REQUIRED, 'The database driver your application will use')
+            ->addOption('no-migrate', 'nm', InputOption::VALUE_NONE, 'Disable to run the migrate command')
             ->addOption('stack', null, InputOption::VALUE_OPTIONAL, 'The Breeze / Jetstream stack that should be installed')
             ->addOption('breeze', null, InputOption::VALUE_NONE, 'Installs the Laravel Breeze scaffolding')
             ->addOption('jet', null, InputOption::VALUE_NONE, 'Installs the Laravel Jetstream scaffolding')
@@ -187,7 +188,7 @@ class NewCommand extends Command
 
                 $this->configureDefaultDatabaseConnection($directory, $database, $name);
 
-                if ($migrate) {
+                if ($migrate && ! $input->getOption('no-migrate')) {
                     $this->runCommands([
                         $this->phpBinary().' artisan migrate',
                     ], $input, $output, workingPath: $directory);


### PR DESCRIPTION
I've created a project and at first, I wanted to modify the user migration. But when I migrated the migrations, there was no migration to migrate!! and I was forced to run `migrate:rollback` and migrate again and it's bad.
I added a new option for someone who needs to create a project without running the `migrate` command.

```shell
laravel new milwad --no-migrate
laravel new milwad -nm
```