### PR TITLE
[1.x] Enforce output when running with `--quiet`

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -761,7 +761,7 @@ class NewCommand extends Command
     protected function getTld()
     {
         foreach (['herd', 'valet'] as $tool) {
-            $process = new Process([$tool, 'tld']);
+            $process = new Process([$tool, 'tld', '-v']);
 
             $process->run();
 
@@ -793,7 +793,7 @@ class NewCommand extends Command
     protected function isParked(string $directory)
     {
         foreach (['herd', 'valet'] as $tool) {
-            $process = new Process([$tool, 'paths']);
+            $process = new Process([$tool, 'paths', '-v']);
 
             $process->run();
 


### PR DESCRIPTION
This PR fixes a bug when running the installer with the `--quiet` option.

## Output
<img width="1416" alt="image" src="https://github.com/laravel/installer/assets/823088/b4ad8eb5-55e8-4a02-9e95-85043c0f9068">

The `-v` enforces the output so that error should not happen anymore.

Thanks