### PR TITLE
[5.x] Fixes issue if there is no `herd` or `valet` installed

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Exception\ProcessStartFailedException;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
+
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\select;
@@ -787,7 +788,6 @@ class NewCommand extends Command
         return $output !== false ? in_array(dirname($directory), json_decode($output)) : false;
     }
 
-
     /**
      * Runs the given command on "herd" or "valet" cli.
      *
@@ -805,7 +805,8 @@ class NewCommand extends Command
                 if ($process->isSuccessful()) {
                     return trim($process->getOutput());
                 }
-            } catch (ProcessStartFailedException) {}
+            } catch (ProcessStartFailedException) {
+            }
         }
 
         return false;

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -789,30 +789,6 @@ class NewCommand extends Command
     }
 
     /**
-     * Runs the given command on "herd" or "valet" cli.
-     *
-     * @param  string  $command
-     * @return string|bool
-     */
-    protected function runOnValetOrHerd(string $command)
-    {
-        foreach (['herd', 'valet'] as $tool) {
-            $process = new Process([$tool, $command, '-v']);
-
-            try {
-                $process->run();
-
-                if ($process->isSuccessful()) {
-                    return trim($process->getOutput());
-                }
-            } catch (ProcessStartFailedException) {
-            }
-        }
-
-        return false;
-    }
-
-    /**
      * Get the version that should be downloaded.
      *
      * @param  \Symfony\Component\Console\Input\InputInterface  $input
@@ -849,6 +825,30 @@ class NewCommand extends Command
         return $phpBinary !== false
             ? ProcessUtils::escapeArgument($phpBinary)
             : 'php';
+    }
+
+    /**
+     * Runs the given command on the "herd" or "valet" CLI.
+     *
+     * @param  string  $command
+     * @return string|bool
+     */
+    protected function runOnValetOrHerd(string $command)
+    {
+        foreach (['herd', 'valet'] as $tool) {
+            $process = new Process([$tool, $command, '-v']);
+
+            try {
+                $process->run();
+
+                if ($process->isSuccessful()) {
+                    return trim($process->getOutput());
+                }
+            } catch (ProcessStartFailedException) {
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
This PR fixes the issue #342.

I could not replicate on my machine but based on the error information provided by @Anticom, catching the `ProcessStartFailedException` it should solve.

Cheers.