### PR TITLE
Automatically run migration when `--database` is given.

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -177,11 +177,11 @@ class NewCommand extends Command
         $composer = $this->findComposer();
         $phpBinary = $this->phpBinary();
 
-        $commands = array_filter([
+        $commands = [
             $composer." create-project laravel/laravel \"$directory\" $version --remove-vcs --prefer-dist --no-scripts",
             $composer." run post-root-package-install -d \"$directory\"",
             $phpBinary." \"$directory/artisan\" key:generate --ansi",
-        ]);
+        ];
 
         if ($directory != '.' && $input->getOption('force')) {
             if (PHP_OS_FAMILY == 'Windows') {

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -177,11 +177,11 @@ class NewCommand extends Command
         $composer = $this->findComposer();
         $phpBinary = $this->phpBinary();
 
-        $commands = [
+        $commands = array_filter([
             $composer." create-project laravel/laravel \"$directory\" $version --remove-vcs --prefer-dist --no-scripts",
             $composer." run post-root-package-install -d \"$directory\"",
             $phpBinary." \"$directory/artisan\" key:generate --ansi",
-        ];
+        ]);
 
         if ($directory != '.' && $input->getOption('force')) {
             if (PHP_OS_FAMILY == 'Windows') {
@@ -492,7 +492,7 @@ class NewCommand extends Command
             );
         }
 
-        return [$input->getOption('database') ?? $defaultDatabase, $migrate ?? false];
+        return [$input->getOption('database') ?? $defaultDatabase, $migrate ?? $input->hasOption('database')];
     }
 
     /**


### PR DESCRIPTION
Since we now run `composer create-project` with `--no-scripts` the command should run migration when `--database` option is available.

fixes #345

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
