### PR TITLE
[5.x] Add support for custom template

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -61,7 +61,8 @@ class NewCommand extends Command
             ->addOption('phpunit', null, InputOption::VALUE_NONE, 'Installs the PHPUnit testing framework')
             ->addOption('prompt-breeze', null, InputOption::VALUE_NONE, 'Issues a prompt to determine if Breeze should be installed (Deprecated)')
             ->addOption('prompt-jetstream', null, InputOption::VALUE_NONE, 'Issues a prompt to determine if Jetstream should be installed (Deprecated)')
-            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Forces install even if the directory already exists');
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Forces install even if the directory already exists')
+            ->addOption('template', 't', InputOption::VALUE_OPTIONAL, 'The laravel template to use', 'laravel/laravel');
     }
 
     /**
@@ -160,6 +161,8 @@ class NewCommand extends Command
 
         $name = $input->getArgument('name');
 
+        $template = $input->getOption('template');
+
         $directory = $this->getInstallationDirectory($name);
 
         $this->composer = new Composer(new Filesystem(), $directory);
@@ -178,7 +181,7 @@ class NewCommand extends Command
         $phpBinary = $this->phpBinary();
 
         $commands = [
-            $composer." create-project laravel/laravel \"$directory\" $version --remove-vcs --prefer-dist --no-scripts",
+            $composer." create-project $template \"$directory\" $version --remove-vcs --prefer-dist --no-scripts",
             $composer." run post-root-package-install -d \"$directory\"",
             $phpBinary." \"$directory/artisan\" key:generate --ansi",
         ];


### PR DESCRIPTION
This feature was [attempted 3 years ago](https://github.com/laravel/installer/pull/206) but was rejected. But with changes in the landscape and more people finding out about the awesome benefits of Laravel coming from JavaScript world, they're used to easy to get started with `create-*-app` style installers.

The default laravel installer is great, but as end users there's a lot left to be desired. Being able to quickly scaffold out a jetstream or a breeze app is fine, but allowing the community to build out more robust starting skeletons and giving a Laravel sanctioned way to install those skeletons will improve people picking up Laravel a lot quicker.

## Usage
You can now just utilize the `--template` flag to specify a non-default skeleton template to use, (this defaults to `laravel/laravel`) like so:

```sh
laravel new blog --template foo/laravel-blog
```

## Prerequisites
* Template repository should have been submited to composer's [packagist](https://packagist.org)
* Template repository should have at least a release tag for it to be installed.
* Template repository should have a `master` branch if the `--dev` installer option is specified as installer expects.

## Considerations
Some of the options should be ignored when using a template that isn't the default, so maybe I can amend this PR to disable breeze/jetstream/etc if `--template` flag is used.