### PR TITLE
Feature/reversable prompt to the laravel install proecess

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^8.2",
         "illuminate/filesystem": "^10.20|^11.0",
         "illuminate/support": "^10.20|^11.0",
-        "laravel/prompts": "^0.1",
+        "laravel/prompts": "^0.1.23",
         "symfony/console": "^6.2|^7.0",
         "symfony/process": "^6.2|^7.0"
     },

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -2,15 +2,18 @@
 
 namespace Laravel\Installer\Console;
 
-use Illuminate\Support\Traits\Conditionable;
-use Laravel\Prompts\FormBuilder as BaseFormBuilder;
+use Closure;
 
-class FormBuilder extends BaseFormBuilder
+class FormBuilder extends \Laravel\Prompts\FormBuilder
 {
-    use Conditionable;
-
-    public static function make(): self
+    public function addWithCondition(Closure $step, ?string $name = null, bool $ignoreWhenReverting = false, bool|Closure $condition = true): self
     {
-        return new self();
+        $this->steps[] = new \Laravel\Prompts\FormStep($step, $condition, $name, $ignoreWhenReverting);
+        return $this;
+    }
+
+    public function getStepsCount()
+    {
+        return count($this->steps);
     }
 }

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -9,10 +9,11 @@ class FormBuilder extends \Laravel\Prompts\FormBuilder
     public function addWithCondition(Closure $step, ?string $name = null, bool $ignoreWhenReverting = false, bool|Closure $condition = true): self
     {
         $this->steps[] = new \Laravel\Prompts\FormStep($step, $condition, $name, $ignoreWhenReverting);
+
         return $this;
     }
 
-    public function getStepsCount()
+    public function getStepsCount(): int
     {
         return count($this->steps);
     }

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Laravel\Installer\Console;
+
+use Illuminate\Support\Traits\Conditionable;
+use Laravel\Prompts\FormBuilder as BaseFormBuilder;
+
+class FormBuilder extends BaseFormBuilder
+{
+    use Conditionable;
+
+    public static function make(): self
+    {
+        return new self();
+    }
+}

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -19,6 +19,7 @@ use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\select;
 use function Laravel\Prompts\text;
+use function Laravel\Prompts\form;
 
 class NewCommand extends Command
 {
@@ -30,6 +31,11 @@ class NewCommand extends Command
      * @var \Illuminate\Support\Composer
      */
     protected $composer;
+
+    /**
+     * @var FormBuilder
+     */
+    protected $form;
 
     /**
      * Configure the command options.
@@ -77,42 +83,51 @@ class NewCommand extends Command
 
         $this->configurePrompts($input, $output);
 
-        $output->write(PHP_EOL.'  <fg=red> _                               _
+        $this->form = FormBuilder::make();
+
+        $this->form->add(
+            fn () => $output->write(PHP_EOL.'  <fg=red> _                               _
   | |                             | |
   | |     __ _ _ __ __ ___   _____| |
   | |    / _` | \'__/ _` \ \ / / _ \ |
   | |___| (_| | | | (_| |\ V /  __/ |
-  |______\__,_|_|  \__,_| \_/ \___|_|</>'.PHP_EOL.PHP_EOL);
-
-        if (! $input->getArgument('name')) {
-            $input->setArgument('name', text(
-                label: 'What is the name of your project?',
-                placeholder: 'E.g. example-app',
-                required: 'The project name is required.',
-                validate: function ($value) use ($input) {
-                    if (preg_match('/[^\pL\pN\-_.]/', $value) !== 0) {
-                        return 'The name may only contain letters, numbers, dashes, underscores, and periods.';
-                    }
-
-                    if ($input->getOption('force') !== true) {
-                        try {
-                            $this->verifyApplicationDoesntExist($this->getInstallationDirectory($value));
-                        } catch (RuntimeException $e) {
-                            return 'Application already exists.';
+  |______\__,_|_|  \__,_| \_/ \___|_|</>'.PHP_EOL.PHP_EOL),
+            ignoreWhenReverting: true
+            )->when(
+            !$input->getArgument('name'),
+            fn () => $this->form->add(
+                fn () => text(
+                    label: 'What is the name of your project?',
+                    placeholder: 'E.g. example-app',
+                    required: 'The project name is required.',
+                    validate: function ($value) use ($input) {
+                        if (preg_match('/[^\pL\pN\-_.]/', $value) !== 0) {
+                            return 'The name may only contain letters, numbers, dashes, underscores, and periods.';
                         }
-                    }
-                },
-            ));
-        }
 
-        if ($input->getOption('force') !== true) {
-            $this->verifyApplicationDoesntExist(
-                $this->getInstallationDirectory($input->getArgument('name'))
-            );
-        }
-
-        if (! $input->getOption('breeze') && ! $input->getOption('jet')) {
-            match (select(
+                        if ($input->getOption('force') !== true) {
+                            try {
+                                $this->verifyApplicationDoesntExist($this->getInstallationDirectory($value));
+                            } catch (RuntimeException $e) {
+                                return 'Application already exists.';
+                            }
+                        }
+                    },
+                ),
+                name: 'name',
+            )->add(fn ($responses) => $input->setArgument('name', $responses['name']), ignoreWhenReverting: true)
+        )->when(
+            $input->getOption('force') !== true,
+            fn () => $this->form->add(
+                fn () => $this->verifyApplicationDoesntExist(
+                    $this->getInstallationDirectory($input->getArgument('name'))
+                ),
+                ignoreWhenReverting: true
+            )
+        )->when(
+     !$input->getOption('breeze') && !$input->getOption('jet'),
+            fn () => $this->form->add(
+                fn () => select(
                 label: 'Would you like to install a starter kit?',
                 options: [
                     'none' => 'No starter kit',
@@ -120,30 +135,44 @@ class NewCommand extends Command
                     'jetstream' => 'Laravel Jetstream',
                 ],
                 default: 'none',
-            )) {
-                'breeze' => $input->setOption('breeze', true),
-                'jetstream' => $input->setOption('jet', true),
-                default => null,
-            };
-        }
-
-        if ($input->getOption('breeze')) {
-            $this->promptForBreezeOptions($input);
-        } elseif ($input->getOption('jet')) {
-            $this->promptForJetstreamOptions($input);
-        }
-
-        if (! $input->getOption('phpunit') && ! $input->getOption('pest')) {
-            $input->setOption('pest', select(
-                label: 'Which testing framework do you prefer?',
-                options: ['Pest', 'PHPUnit'],
-                default: 'Pest',
-            ) === 'Pest');
-        }
-
-        if (! $input->getOption('git') && $input->getOption('github') === false && Process::fromShellCommandline('git --version')->run() === 0) {
-            $input->setOption('git', confirm(label: 'Would you like to initialize a Git repository?', default: false));
-        }
+                ),
+                name: 'starterKit',
+            )->add(
+                fn ($responses) => match ($responses['starterKit']) {
+                    'breeze' => $input->setOption('breeze', true),
+                    'jetstream' => $input->setOption('jet', true),
+                    default => null,
+                },
+                ignoreWhenReverting: true
+            )
+        )->when(
+            $input->getOption('breeze'),
+            fn () => $this->promptForBreezeOptions($input)
+        )->when(
+            $input->getOption('jet'),
+            fn () => $this->promptForJetstreamOptions($input)
+        )->when(
+            ! $input->getOption('phpunit') && ! $input->getOption('pest'),
+            fn () => $this->form->add(
+                fn () => select(
+                        label: 'Which testing framework do you prefer?',
+                        options: ['Pest', 'PHPUnit'],
+                        default: 'Pest',
+                    ) === 'Pest',
+                name: 'pest',
+            )->add(
+                fn ($responses) => $input->setOption('pest', $responses['pest'])
+                )
+        )->when(
+            ! $input->getOption('git') && $input->getOption('github') === false && Process::fromShellCommandline('git --version')->run() === 0,
+            fn () => $this->form->add(
+                fn () => confirm(label: 'Would you like to initialize a Git repository?', default: false),
+                name: 'git',
+            )->add(
+                fn ($responses) => $input->setOption('git', $responses['git'])
+            )
+        )
+        ->submit();
     }
 
     /**
@@ -521,41 +550,57 @@ class NewCommand extends Command
      */
     protected function promptForBreezeOptions(InputInterface $input)
     {
-        if (! $input->getOption('stack')) {
-            $input->setOption('stack', select(
-                label: 'Which Breeze stack would you like to install?',
-                options: [
-                    'blade' => 'Blade with Alpine',
-                    'livewire' => 'Livewire (Volt Class API) with Alpine',
-                    'livewire-functional' => 'Livewire (Volt Functional API) with Alpine',
-                    'react' => 'React with Inertia',
-                    'vue' => 'Vue with Inertia',
-                    'api' => 'API only',
-                ],
-                default: 'blade',
-            ));
-        }
-
-        if (in_array($input->getOption('stack'), ['react', 'vue']) && (! $input->getOption('dark') || ! $input->getOption('ssr'))) {
-            collect(multiselect(
-                label: 'Would you like any optional features?',
-                options: [
-                    'dark' => 'Dark mode',
-                    'ssr' => 'Inertia SSR',
-                    'typescript' => 'TypeScript',
-                ],
-                default: array_filter([
-                    $input->getOption('dark') ? 'dark' : null,
-                    $input->getOption('ssr') ? 'ssr' : null,
-                    $input->getOption('typescript') ? 'typescript' : null,
-                ]),
-            ))->each(fn ($option) => $input->setOption($option, true));
-        } elseif (in_array($input->getOption('stack'), ['blade', 'livewire', 'livewire-functional']) && ! $input->getOption('dark')) {
-            $input->setOption('dark', confirm(
-                label: 'Would you like dark mode support?',
-                default: false,
-            ));
-        }
+        $this->form->when(
+            ! $input->getOption('stack'),
+            fn () => $this->form->add(
+                fn () => select(
+                    label: 'Which Breeze stack would you like to install?',
+                    options: [
+                        'blade' => 'Blade with Alpine',
+                        'livewire' => 'Livewire (Volt Class API) with Alpine',
+                        'livewire-functional' => 'Livewire (Volt Functional API) with Alpine',
+                        'react' => 'React with Inertia',
+                        'vue' => 'Vue with Inertia',
+                        'api' => 'API only',
+                    ],
+                    default: 'blade',
+                ),
+                name: 'stack',
+            )->add(
+                fn ($responses) => $input->setOption('stack', $responses['stack'])
+            )
+        )->add(function () use ($input) {
+            if (in_array($input->getOption('stack'), ['react', 'vue']) && (! $input->getOption('dark') || ! $input->getOption('ssr'))) {
+                $this->form->add(
+                    fn () => multiselect(
+                        label: 'Would you like any optional features?',
+                        options: [
+                            'dark' => 'Dark mode',
+                            'ssr' => 'Inertia SSR',
+                            'typescript' => 'TypeScript',
+                        ],
+                        default: array_filter([
+                            $input->getOption('dark') ? 'dark' : null,
+                            $input->getOption('ssr') ? 'ssr' : null,
+                            $input->getOption('typescript') ? 'typescript' : null,
+                        ]),
+                    ),
+                    name: 'features',
+                )->add (
+                    fn ($responses) => collect($responses['features'])->each(fn ($feature) => $input->setOption($feature, true))
+                );
+            } elseif (in_array($input->getOption('stack'), ['blade', 'livewire', 'livewire-functional']) && ! $input->getOption('dark')) {
+                $this->form->add(
+                    fn () => confirm(
+                        label: 'Would you like dark mode support?',
+                        default: false,
+                    ),
+                    name: 'supportDarkMode',
+                )->add(
+                    fn ($responses) => $input->setOption('dark', $responses['supportDarkMode'])
+                );
+            }
+        });
     }
 
     /**
@@ -566,36 +611,45 @@ class NewCommand extends Command
      */
     protected function promptForJetstreamOptions(InputInterface $input)
     {
-        if (! $input->getOption('stack')) {
-            $input->setOption('stack', select(
-                label: 'Which Jetstream stack would you like to install?',
-                options: [
-                    'livewire' => 'Livewire',
-                    'inertia' => 'Vue with Inertia',
-                ],
-                default: 'livewire',
-            ));
-        }
-
-        collect(multiselect(
-            label: 'Would you like any optional features?',
-            options: collect([
-                'api' => 'API support',
-                'dark' => 'Dark mode',
-                'verification' => 'Email verification',
-                'teams' => 'Team support',
-            ])->when(
-                $input->getOption('stack') === 'inertia',
-                fn ($options) => $options->put('ssr', 'Inertia SSR')
-            )->all(),
-            default: array_filter([
-                $input->getOption('api') ? 'api' : null,
-                $input->getOption('dark') ? 'dark' : null,
-                $input->getOption('teams') ? 'teams' : null,
-                $input->getOption('verification') ? 'verification' : null,
-                $input->getOption('stack') === 'inertia' && $input->getOption('ssr') ? 'ssr' : null,
-            ]),
-        ))->each(fn ($option) => $input->setOption($option, true));
+        $this->form->when(
+            ! $input->getOption('stack'),
+            fn () => $this->form->add(
+                fn () => select(
+                    label: 'Which Jetstream stack would you like to install?',
+                    options: [
+                        'livewire' => 'Livewire',
+                        'inertia' => 'Vue with Inertia',
+                    ],
+                    default: 'livewire',
+                ),
+                name: 'jetStreamStack',
+            )->add(
+                fn ($responses) => $input->setOption('stack', $responses['jetStreamStack'])
+            )
+        )->add(
+            fn () => $this->form->multiselect(
+                label: 'Would you like any optional features?',
+                options: collect([
+                    'api' => 'API support',
+                    'dark' => 'Dark mode',
+                    'verification' => 'Email verification',
+                    'teams' => 'Team support',
+                ])->when(
+                    $input->getOption('stack') === 'inertia',
+                    fn ($options) => $options->put('ssr', 'Inertia SSR')
+                )->all(),
+                default: array_filter([
+                    $input->getOption('api') ? 'api' : null,
+                    $input->getOption('dark') ? 'dark' : null,
+                    $input->getOption('teams') ? 'teams' : null,
+                    $input->getOption('verification') ? 'verification' : null,
+                    $input->getOption('stack') === 'inertia' && $input->getOption('ssr') ? 'ssr' : null,
+                ]),
+            ),
+            name: 'features',
+        )->add(
+            fn ($responses) => collect($responses['features'])->each(fn ($feature) => $input->setOption($feature, true))
+        );
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -131,7 +131,7 @@ class NewCommand extends Command
 
                 return true;
             },
-            condition: !$input->getOption('breeze') && !$input->getOption('jet')
+            condition: ! $input->getOption('breeze') && ! $input->getOption('jet')
         )->addWithCondition(
             function () use ($input) {
                 $this->promptForBreezeOptions($input);
@@ -143,7 +143,7 @@ class NewCommand extends Command
             },
             condition: fn () => $input->getOption('jet')
         )->addWithCondition(
-            function () use($input) {
+            function () use ($input) {
                 $input->setOption('pest', select(
                     label: 'Which testing framework do you prefer?',
                     options: ['Pest', 'PHPUnit'],

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -101,7 +101,7 @@ class NewCommand extends Command
                     }
                 },
             )),
-            condition: !$input->getArgument('name')
+            condition: ! $input->getArgument('name')
         )->addWithCondition(
             fn () => $this->verifyApplicationDoesntExist(
                 $this->getInstallationDirectory($input->getArgument('name'))
@@ -133,26 +133,26 @@ class NewCommand extends Command
             },
             condition: !$input->getOption('breeze') && !$input->getOption('jet')
         )->addWithCondition(
-            function () use($input) {
+            function () use ($input) {
                 $this->promptForBreezeOptions($input);
             },
             condition: fn () => $input->getOption('breeze')
         )->addWithCondition(
-            function () use($input) {
+            function () use ($input) {
                 $this->promptForJetstreamOptions($input);
             },
             condition: fn () => $input->getOption('jet')
         )->addWithCondition(
             function () use($input) {
                 $input->setOption('pest', select(
-                        label: 'Which testing framework do you prefer?',
-                        options: ['Pest', 'PHPUnit'],
-                        default: 'Pest',
-                    ) === 'Pest');
+                    label: 'Which testing framework do you prefer?',
+                    options: ['Pest', 'PHPUnit'],
+                    default: 'Pest',
+                ) === 'Pest');
             },
             condition: ! $input->getOption('phpunit') && ! $input->getOption('pest')
         )->addWithCondition(
-            function () use($input) {
+            function () use ($input) {
                 $input->setOption('git', confirm(label: 'Would you like to initialize a Git repository?', default: false));
             },
             condition: ! $input->getOption('git')

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Installer\Console\Tests;
+
+use Laravel\Installer\Console\FormBuilder;
+use PHPUnit\Framework\TestCase;
+
+class FormBuilderTest extends TestCase
+{
+    public function test_add_with_condition(): void
+    {
+        $formBuilder = new FormBuilder;
+        $formBuilder->addWithCondition(function () {
+            return 'test';
+        });
+        $this->assertEquals(1, $formBuilder->getStepsCount());
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hey all!

This PR adds support for revertable forms to Prompts. Here's a little demo video:

https://github.com/laravel/installer/assets/4625540/87f93da2-5533-4c18-8853-db9cbc9a1e89

### Purpose
If I make typos or mistakes and need to go back to make edits. Currently, the only way to fix them is to cancel
the command and start again from scratch.

To fix that frustration, you may now declare a series of steps that the user will
be taken through. By using the CTRL+U key combo, any step in the process can be
reverted by the user to retry the previous step again.

This is a new feature of laravel/prompts.

### Wrap-up
 I'm excited to hear your thoughts!

Thank you for all the hard work maintaining and working on Laravel/Installer; it's very much appreciated.

Regards,
Fermin Perdomo