### PR TITLE
Fix `--no-interaction` SQLite file prompt

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -211,7 +211,7 @@ class NewCommand extends Command
                     $commands = [
                         trim(sprintf(
                             $this->phpBinary().' artisan migrate %s',
-                            $input->getOption('no-interaction') ? '--force' : '',
+                            $database === 'sqlite' && ! $input->isInteractive() ? '--force' : '',
                         )),
                     ];
                     $this->runCommands($commands, $input, $output, workingPath: $directory);

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -214,7 +214,7 @@ class NewCommand extends Command
                     $commands = [
                         trim(sprintf(
                             $this->phpBinary().' artisan migrate %s',
-                            ! $input->isInteractive() ? '--force' : '',
+                            ! $input->isInteractive() ? '--no-interaction' : '',
                         )),
                     ];
                     $this->runCommands($commands, $input, $output, workingPath: $directory);

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -211,12 +211,14 @@ class NewCommand extends Command
                     if ($database === 'sqlite') {
                         touch($directory.'/database/database.sqlite');
                     }
+
                     $commands = [
                         trim(sprintf(
                             $this->phpBinary().' artisan migrate %s',
                             ! $input->isInteractive() ? '--no-interaction' : '',
                         )),
                     ];
+
                     $this->runCommands($commands, $input, $output, workingPath: $directory);
                 }
             }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -208,9 +208,13 @@ class NewCommand extends Command
                 $this->configureDefaultDatabaseConnection($directory, $database, $name);
 
                 if ($migrate) {
-                    $this->runCommands([
-                        $this->phpBinary().' artisan migrate',
-                    ], $input, $output, workingPath: $directory);
+                    $commands = [
+                        trim(sprintf(
+                            $this->phpBinary().' artisan migrate %s',
+                            $input->getOption('no-interaction') ? '--force' : '',
+                        )),
+                    ];
+                    $this->runCommands($commands, $input, $output, workingPath: $directory);
                 }
             }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -208,10 +208,13 @@ class NewCommand extends Command
                 $this->configureDefaultDatabaseConnection($directory, $database, $name);
 
                 if ($migrate) {
+                    if ($database === 'sqlite') {
+                        touch($directory.'/database/database.sqlite');
+                    }
                     $commands = [
                         trim(sprintf(
                             $this->phpBinary().' artisan migrate %s',
-                            $database === 'sqlite' && ! $input->isInteractive() ? '--force' : '',
+                            ! $input->isInteractive() ? '--force' : '',
                         )),
                     ];
                     $this->runCommands($commands, $input, $output, workingPath: $directory);


### PR DESCRIPTION
Fixes https://github.com/laravel/installer/issues/352

This prompt comes from the `migrate` command, and [by the looks of that](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Database/Console/Migrations/MigrateCommand.php#L196) the only way to ensure the SQLite file is created without a prompt is to add `--force`. Adding `--no-interaction` to `migrate` results in no file being created, which then errors when the migrations run.

Hopefully this is OK but let me know if you'd like any changes.