### PR TITLE
Undo git question comment

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -142,9 +142,9 @@ class NewCommand extends Command
             ) === 'Pest');
         }
 
-        // if (! $input->getOption('git') && $input->getOption('github') === false && Process::fromShellCommandline('git --version')->run() === 0) {
-        //     $input->setOption('git', confirm(label: 'Would you like to initialize a Git repository?', default: false));
-        // }
+        if (! $input->getOption('git') && $input->getOption('github') === false && Process::fromShellCommandline('git --version')->run() === 0) {
+            $input->setOption('git', confirm(label: 'Would you like to initialize a Git repository?', default: false));
+        }
     }
 
     /**


### PR DESCRIPTION
Recently noticed the git question was removed, it's quite a useful options to have.

Perhaps slightly off-topic; the changes were made here https://github.com/laravel/installer/commit/667c610382f2052e69ff60b10811fdaa9376aeef without a PR and not a mention in the release notes. Shouldn't changes like these at least be mentioned in the release notes? That way it would also likely include reasoning as to why it was removed, now it's just commented out.