### PR TITLE
[5.x] Remove `php artisan pail` from `composer run dev` on Windows 

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -241,7 +241,7 @@ class NewCommand extends Command
                 $output->writeln('');
             }
 
-            $this->configureComposerScript($directory);
+            $this->configureComposerDevScript($directory);
 
             $output->writeln("  <bg=blue;fg=white> INFO </> Application ready in <options=bold>[{$name}]</>. You can start your local development using:".PHP_EOL);
             $output->writeln('<fg=gray>➜</> <options=bold>cd '.$name.'</>');
@@ -346,23 +346,6 @@ class NewCommand extends Command
             'DB_DATABASE='.str_replace('-', '_', strtolower($name)),
             $directory.'/.env.example'
         );
-    }
-
-    /**
-     * Configure Composer's Script.
-     *
-     * @param  string  $directory
-     * @return void
-     */
-    protected function configureComposerScript(string $directory): void
-    {
-        $this->composer->modify(function (array $content) {
-            if (windows_os()) {
-                $content['scripts']['dev'] = "npx concurrently -c \"#93c5fd,#c4b5fd,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"npm run dev\" --names='server,queue,vite'";
-            }
-
-            return $content;
-        });
     }
 
     /**
@@ -777,6 +760,23 @@ class NewCommand extends Command
         $this->runCommands($commands, $input, $output, workingPath: $directory, env: ['GIT_TERMINAL_PROMPT' => 0]);
     }
 
+    /**
+     * Configure the Composer "dev" script.
+     *
+     * @param  string  $directory
+     * @return void
+     */
+    protected function configureComposerDevScript(string $directory): void
+    {
+        $this->composer->modify(function (array $content) {
+            if (windows_os()) {
+                $content['scripts']['dev'] = "npx concurrently -c \"#93c5fd,#c4b5fd,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"npm run dev\" --names='server,queue,vite'";
+            }
+
+            return $content;
+        });
+    }
+    
     /**
      * Verify that the application does not already exist.
      *

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -241,6 +241,8 @@ class NewCommand extends Command
                 $output->writeln('');
             }
 
+            $this->configureComposerScript($directory);
+
             $output->writeln("  <bg=blue;fg=white> INFO </> Application ready in <options=bold>[{$name}]</>. You can start your local development using:".PHP_EOL);
             $output->writeln('<fg=gray>➜</> <options=bold>cd '.$name.'</>');
             $output->writeln('<fg=gray>➜</> <options=bold>npm install && npm run build</>');
@@ -344,6 +346,23 @@ class NewCommand extends Command
             'DB_DATABASE='.str_replace('-', '_', strtolower($name)),
             $directory.'/.env.example'
         );
+    }
+
+    /**
+     * Configure Composer's Script
+     *
+     * @param  string  $directory
+     * @return void
+     */
+    protected function configureComposerScript(string $directory): void
+    {
+        $this->composer->modify(function (array $content) {
+            if (windows_os()) {
+                $content['scripts']['dev'] = "npx concurrently -c \"#93c5fd,#c4b5fd,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"npm run dev\" --names=server,queue,vite";
+            }
+
+            return $content;
+        });
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -358,7 +358,7 @@ class NewCommand extends Command
     {
         $this->composer->modify(function (array $content) {
             if (windows_os()) {
-                $content['scripts']['dev'] = "npx concurrently -c \"#93c5fd,#c4b5fd,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"npm run dev\" --names={{ 'server,queue,vite' }}";
+                $content['scripts']['dev'] = "npx concurrently -c \"#93c5fd,#c4b5fd,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"npm run dev\" --names='server,queue,vite'";
             }
 
             return $content;

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -349,7 +349,7 @@ class NewCommand extends Command
     }
 
     /**
-     * Configure Composer's Script
+     * Configure Composer's Script.
      *
      * @param  string  $directory
      * @return void
@@ -358,7 +358,7 @@ class NewCommand extends Command
     {
         $this->composer->modify(function (array $content) {
             if (windows_os()) {
-                $content['scripts']['dev'] = "npx concurrently -c \"#93c5fd,#c4b5fd,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"npm run dev\" --names=server,queue,vite";
+                $content['scripts']['dev'] = 'npx concurrently -c "#93c5fd,#c4b5fd,#fdba74" "php artisan serve" "php artisan queue:listen --tries=1" "npm run dev" --names=server,queue,vite';
             }
 
             return $content;

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -358,7 +358,7 @@ class NewCommand extends Command
     {
         $this->composer->modify(function (array $content) {
             if (windows_os()) {
-                $content['scripts']['dev'] = 'npx concurrently -c "#93c5fd,#c4b5fd,#fdba74" "php artisan serve" "php artisan queue:listen --tries=1" "npm run dev" --names=server,queue,vite';
+                $content['scripts']['dev'] = "npx concurrently -c \"#93c5fd,#c4b5fd,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"npm run dev\" --names={{ 'server,queue,vite' }}";
             }
 
             return $content;


### PR DESCRIPTION
Fixes #365