### PR TITLE
Remove any trailing slash from application name

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -810,7 +810,7 @@ class NewCommand extends Command
      */
     protected function getTld()
     {
-        return $this->runOnValetOrHerd('tld') ?? 'test';
+        return $this->runOnValetOrHerd('tld') ?: 'test';
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -159,7 +159,7 @@ class NewCommand extends Command
         $this->validateDatabaseOption($input);
         $this->validateStackOption($input);
 
-        $name = $input->getArgument('name');
+        $name = $this->trimTrailingSlash($input->getArgument('name'));
 
         $directory = $this->getInstallationDirectory($name);
 
@@ -1017,5 +1017,16 @@ class NewCommand extends Command
             $file,
             preg_replace($pattern, $replace, file_get_contents($file))
         );
+    }
+
+    /**
+     * Remove any trailing slashes from the application name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function trimTrailingSlash(string $name)
+    {
+        return mb_rtrim($name, '/\\');
     }
 }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -159,7 +159,7 @@ class NewCommand extends Command
         $this->validateDatabaseOption($input);
         $this->validateStackOption($input);
 
-        $name = $this->trimTrailingSlash($input->getArgument('name'));
+        $name = mb_rtrim($input->getArgument('name'), '/\\');
 
         $directory = $this->getInstallationDirectory($name);
 
@@ -1017,16 +1017,5 @@ class NewCommand extends Command
             $file,
             preg_replace($pattern, $replace, file_get_contents($file))
         );
-    }
-
-    /**
-     * Remove any trailing slashes from the application name.
-     *
-     * @param  string  $name
-     * @return string
-     */
-    protected function trimTrailingSlash(string $name)
-    {
-        return mb_rtrim($name, '/\\');
     }
 }

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -34,6 +34,32 @@ class NewCommandTest extends TestCase
         $this->assertFileExists($scaffoldDirectory.'/.env');
     }
 
+    public function test_it_can_chops_trailing_slash_from_name()
+    {
+        $scaffoldDirectoryName = 'tests-output/trailing/';
+        $scaffoldDirectory = __DIR__.'/../'.$scaffoldDirectoryName;
+
+        if (file_exists($scaffoldDirectory)) {
+            if (PHP_OS_FAMILY == 'Windows') {
+                exec("rd /s /q \"$scaffoldDirectory\"");
+            } else {
+                exec("rm -rf \"$scaffoldDirectory\"");
+            }
+        }
+
+        $app = new Application('Laravel Installer');
+        $app->add(new NewCommand);
+
+        $tester = new CommandTester($app->find('new'));
+
+        $statusCode = $tester->execute(['name' => $scaffoldDirectoryName], ['interactive' => false]);
+
+        $this->assertSame(0, $statusCode);
+        $this->assertDirectoryExists($scaffoldDirectory.'/vendor');
+        $this->assertFileExists($scaffoldDirectory.'/.env');
+        $this->assertStringContainsStringIgnoringLineEndings('APP_URL=http://tests-output/trailing.test', file_get_contents($scaffoldDirectory.'/.env'));
+    }
+
     public function test_on_at_least_laravel_11()
     {
         $command = new NewCommand;


### PR DESCRIPTION
This PR addresses two, minor issues.

First, due to a logic bug when testing for Herd or Valet, a default `.test` extension could never be reached. This ultimately leads to `APP_URL` always being `http://localhost` instead of a potentially valid `http://app-name.test`.

Second, if a developer appends a trailing slash to the name everything is installed and the application runs. However, all tests will fail until the developer realizes the `APP_URL` was set to `http://app-name/.test`. While an arguably an incorrect use case, it's a pretty easy fix to avoid such an annoying experience.