### PR TITLE
Test Improvements

### DIFF
--- a/src/Concerns/InteractsWithHerdOrValet.php
+++ b/src/Concerns/InteractsWithHerdOrValet.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Laravel\Installer\Console\Concerns;
+
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\Exception\ProcessStartFailedException;
+
+trait InteractsWithHerdOrValet 
+{
+    /**
+     * Determine if the given directory is parked using Herd or Valet.
+     *
+     * @param  string  $directory
+     * @return bool
+     */
+    public function isParkedOnHerdOrValet(string $directory)
+    {
+        $output = $this->runOnValetOrHerd('paths');
+
+        return $output !== false ? in_array(dirname($directory), json_decode($output)) : false;
+    }
+
+    /**
+     * Runs the given command on the "herd" or "valet" CLI.
+     *
+     * @param  string  $command
+     * @return string|false
+     */
+    protected function runOnValetOrHerd(string $command)
+    {
+        foreach (['herd', 'valet'] as $tool) {
+            $process = new Process([$tool, $command, '-v']);
+
+            try {
+                $process->run();
+
+                if ($process->isSuccessful()) {
+                    return trim($process->getOutput());
+                }
+            } catch (ProcessStartFailedException) {
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Installer\Console\Tests;
 
+use Laravel\Installer\Console\Concerns\InteractsWithHerdOrValet;
 use Laravel\Installer\Console\NewCommand;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
@@ -11,6 +12,8 @@ use function Illuminate\Filesystem\join_paths;
 
 class NewCommandTest extends TestCase
 {
+    use InteractsWithHerdOrValet;
+
     public function test_it_can_scaffold_a_new_laravel_app()
     {
         $scaffoldDirectoryName = 'tests-output/my-app';
@@ -38,6 +41,10 @@ class NewCommandTest extends TestCase
 
     public function test_it_can_chops_trailing_slash_from_name()
     {
+        if ($this->runOnValetOrHerd('paths') === false) {
+            $this->markTestSkipped('Require `herd` or `valet` to resolve `APP_URL` using hostname instead of "localhost".');
+        }
+
         $scaffoldDirectoryName = 'tests-output/trailing/';
         $scaffoldDirectory = join_paths(__DIR__, '..', $scaffoldDirectoryName);
 
@@ -59,7 +66,13 @@ class NewCommandTest extends TestCase
         $this->assertSame(0, $statusCode);
         $this->assertDirectoryExists(join_paths($scaffoldDirectory, 'vendor'));
         $this->assertFileExists(join_paths($scaffoldDirectory, '.env'));
-        $this->assertStringContainsStringIgnoringLineEndings('APP_URL=http://tests-output/trailing.test', file_get_contents(join_paths($scaffoldDirectory, '.env')));
+
+        if ($this->isParkedOnHerdOrValet($scaffoldDirectory)) {
+            $this->assertStringContainsStringIgnoringLineEndings(
+                'APP_URL=http://tests-output/trailing.test', 
+                file_get_contents(join_paths($scaffoldDirectory, '.env'))
+            );
+        }
     }
 
     public function test_on_at_least_laravel_11()

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -67,7 +67,7 @@ class NewCommandTest extends TestCase
 
         if ($this->isParkedOnHerdOrValet($scaffoldDirectory)) {
             $this->assertStringContainsStringIgnoringLineEndings(
-                'APP_URL=http://tests-output/trailing.test', 
+                'APP_URL=http://tests-output/trailing.test',
                 file_get_contents($scaffoldDirectory.'/.env')
             );
         }

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
+use function Illuminate\Filesystem\join_paths;
+
 class NewCommandTest extends TestCase
 {
     public function test_it_can_scaffold_a_new_laravel_app()
@@ -37,7 +39,7 @@ class NewCommandTest extends TestCase
     public function test_it_can_chops_trailing_slash_from_name()
     {
         $scaffoldDirectoryName = 'tests-output/trailing/';
-        $scaffoldDirectory = realpath(__DIR__.'/../'.$scaffoldDirectoryName);
+        $scaffoldDirectory = join_paths(__DIR__, '..', $scaffoldDirectoryName);
 
         if (file_exists($scaffoldDirectory)) {
             if (PHP_OS_FAMILY == 'Windows') {
@@ -55,9 +57,9 @@ class NewCommandTest extends TestCase
         $statusCode = $tester->execute(['name' => $scaffoldDirectoryName], ['interactive' => false]);
 
         $this->assertSame(0, $statusCode);
-        $this->assertDirectoryExists($scaffoldDirectory.'/vendor');
-        $this->assertFileExists($scaffoldDirectory.'/.env');
-        $this->assertStringContainsStringIgnoringLineEndings('APP_URL=http://tests-output/trailing.test', file_get_contents($scaffoldDirectory.'/.env'));
+        $this->assertDirectoryExists(join_paths($scaffoldDirectory, 'vendor'));
+        $this->assertFileExists(join_paths($scaffoldDirectory, '.env'));
+        $this->assertStringContainsStringIgnoringLineEndings('APP_URL=http://tests-output/trailing.test', file_get_contents(join_paths($scaffoldDirectory, '.env')));
     }
 
     public function test_on_at_least_laravel_11()

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -37,7 +37,7 @@ class NewCommandTest extends TestCase
     public function test_it_can_chops_trailing_slash_from_name()
     {
         $scaffoldDirectoryName = 'tests-output/trailing/';
-        $scaffoldDirectory = __DIR__.'/../'.$scaffoldDirectoryName;
+        $scaffoldDirectory = realpath(__DIR__.'/../'.$scaffoldDirectoryName);
 
         if (file_exists($scaffoldDirectory)) {
             if (PHP_OS_FAMILY == 'Windows') {

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -8,8 +8,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
-use function Illuminate\Filesystem\join_paths;
-
 class NewCommandTest extends TestCase
 {
     use InteractsWithHerdOrValet;
@@ -46,7 +44,7 @@ class NewCommandTest extends TestCase
         }
 
         $scaffoldDirectoryName = 'tests-output/trailing/';
-        $scaffoldDirectory = join_paths(__DIR__, '..', $scaffoldDirectoryName);
+        $scaffoldDirectory = __DIR__.'/../'.$scaffoldDirectoryName;
 
         if (file_exists($scaffoldDirectory)) {
             if (PHP_OS_FAMILY == 'Windows') {
@@ -64,13 +62,13 @@ class NewCommandTest extends TestCase
         $statusCode = $tester->execute(['name' => $scaffoldDirectoryName], ['interactive' => false]);
 
         $this->assertSame(0, $statusCode);
-        $this->assertDirectoryExists(join_paths($scaffoldDirectory, 'vendor'));
-        $this->assertFileExists(join_paths($scaffoldDirectory, '.env'));
+        $this->assertDirectoryExists($scaffoldDirectory.'/vendor');
+        $this->assertFileExists($scaffoldDirectory.'/.env');
 
         if ($this->isParkedOnHerdOrValet($scaffoldDirectory)) {
             $this->assertStringContainsStringIgnoringLineEndings(
                 'APP_URL=http://tests-output/trailing.test', 
-                file_get_contents(join_paths($scaffoldDirectory, '.env'))
+                file_get_contents($scaffoldDirectory.'/.env')
             );
         }
     }


### PR DESCRIPTION
* Move `herd` and `valet` related code to `Laravel\Installer\Console\Concerns\InteractsWithHerdOrValet`
* Skipped `test_it_can_chops_trailing_slash_from_name` when `valet` or `herd` is missing.