### PR TITLE
[5.x] Add polyfill for `mb_rtrim()` for PHP 8.3 and below

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "illuminate/support": "^10.20|^11.0",
         "laravel/prompts": "^0.1.18|^0.2.0|^0.3.0",
         "symfony/console": "^6.2|^7.0",
+        "symfony/polyfill-mbstring": "^1.31",
         "symfony/process": "^6.2|^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
fixes #372