### PR TITLE
Fix check for current directory

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -822,7 +822,7 @@ class NewCommand extends Command
      */
     protected function verifyApplicationDoesntExist($directory)
     {
-        if ((is_dir($directory) || is_file($directory)) && $directory != getcwd()) {
+        if ((is_dir($directory) || is_file($directory)) && $directory != getcwd() && $directory != '.') {
             throw new RuntimeException('Application already exists!');
         }
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Fix #377

This was the smallest change I could make to fix the issue. It might be better if instead of comparing to `"."` we set change `getInstallationDirectory()` from
```php
        return $name !== '.' ? getcwd().'/'.$name : '.';
```
to
```php
        return $name !== '.' ? getcwd().'/'.$name : getcwd();
```

Any feedback would be appreciated.