### PR TITLE
[5.x] - Add kickstart option

### DIFF
--- a/src/Kickstart/Kickstart.php
+++ b/src/Kickstart/Kickstart.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Installer\Console\Kickstart;
+
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Pluralizer;
+use InvalidArgumentException;
+use RuntimeException;
+use Symfony\Component\Finder\Finder;
+use Throwable;
+
+use function str;
+
+class Kickstart
+{
+    /**
+     * @var Filesystem
+     */
+    protected $fs;
+
+    /**
+     * @var Stub
+     */
+    protected $stub;
+
+    /**
+     * @var Project
+     */
+    protected $project;
+
+    public function __construct(
+        string $projectPath,
+        string $controllerType,
+        string $template,
+        bool $hasTeams,
+        Filesystem $fs = new Filesystem()
+    ) {
+        $this->fs = $fs;
+        $this->project = new Project($projectPath, $hasTeams);
+        $this->stub = new Stub($template, $controllerType, $hasTeams);
+    }
+
+    /**
+     * @return bool|int
+     *
+     * @throws InvalidArgumentException
+     */
+    public function copyDraftToProject()
+    {
+        return $this->fs->put(
+            $this->project()->draftPath(),
+            $this->stub()->content()
+        );
+    }
+
+    /**
+     * @return void
+     *
+     * @throws FileNotFoundException
+     */
+    public function copySeederToProject()
+    {
+        if (! $this->fs->exists($this->project()->draftPath())) {
+            throw new RuntimeException('The draft file does not exist in project');
+        }
+
+        if (! $this->fs->exists($this->stub()->seederPath())) {
+            throw new FileNotFoundException('The seeder stub does not exist');
+        }
+
+        $content = $this->fs->get($this->stub()->seederPath());
+
+        if (! $this->fs->put($this->project()->seederPath(), $content)) {
+            throw new RuntimeException('The seeder file could not be created');
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function deleteGenericSeeders()
+    {
+        $finder = (new Finder())
+            ->files()
+            ->in(dirname($this->project()->seederPath()))
+            ->notName([
+                'KickstartSeeder.php',
+                'DatabaseSeeder.php',
+            ]);
+
+        foreach ($finder as $genericSeederFile) {
+            if (false !== $path = $genericSeederFile->getRealPath()) {
+                $this->fs->delete($path);
+            }
+        }
+    }
+
+    /**
+     * @return string|null
+     *
+     * @throws Throwable
+     */
+    public function missingRequiredMigrationsMessage()
+    {
+        $migrationsDir = $this->project()->migrationsPath();
+
+        [$hasUserMigration, $hasTeamMigration] = [false, ! $this->project()->hasTeams()];
+        foreach (scandir($migrationsDir) ?: [] as $fileName) {
+            if (str($fileName)->is('*create_users_table.php')) {
+                $hasUserMigration = true;
+            }
+
+            if (str($fileName)->is('*create_teams_table.php')) {
+                $hasTeamMigration = true;
+            }
+        }
+
+        if ($hasUserMigration && $hasTeamMigration) {
+            return null;
+        }
+
+        $missingMigrations = collect(['user' => ! $hasUserMigration, 'team' => ! $hasTeamMigration])
+            ->filter()
+            ->keys();
+
+        return sprintf('%s seeder bypassed: the %s %s %s missing',
+            $this->stub()->template(),
+            $missingMigrations->join(' and '),
+            Pluralizer::plural('migration', $missingMigrations),
+            $missingMigrations->count() > 1 ? 'are' : 'is'
+        );
+    }
+
+    /**
+     * @return Project
+     */
+    public function project(): Project
+    {
+        return $this->project;
+    }
+
+    /**
+     * @return Stub
+     */
+    public function stub(): Stub
+    {
+        return $this->stub;
+    }
+}

--- a/src/Kickstart/Project.php
+++ b/src/Kickstart/Project.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Installer\Console\Kickstart;
+
+use InvalidArgumentException;
+
+use function Illuminate\Filesystem\join_paths;
+
+class Project
+{
+    /**
+     * @var bool
+     */
+    protected $hasTeams;
+
+    /**
+     * @var string
+     */
+    protected $basePath;
+
+    public function __construct(string $basePath, bool $hasTeams)
+    {
+        $this->basePath = $basePath;
+        $this->hasTeams = $hasTeams;
+    }
+
+    /**
+     * @return string
+     *
+     * @throws InvalidArgumentException
+     */
+    public function basePath()
+    {
+        throw_unless(
+            is_dir($this->basePath),
+            InvalidArgumentException::class,
+            "The path [{$this->basePath}] does not exist"
+        );
+
+        return $this->basePath;
+    }
+
+    /**
+     * @return string
+     */
+    public function draftPath()
+    {
+        return join_paths($this->basePath, 'draft.yaml');
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasTeams()
+    {
+        return $this->hasTeams;
+    }
+
+    /**
+     * @return string
+     */
+    public function migrationsPath()
+    {
+        return join_paths($this->basePath, 'database', 'migrations');
+    }
+
+    /**
+     * @return string
+     */
+    public function seederPath()
+    {
+        return join_paths($this->basePath, 'database', 'seeders', 'KickstartSeeder.php');
+    }
+}

--- a/src/Kickstart/Stub.php
+++ b/src/Kickstart/Stub.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Installer\Console\Kickstart;
+
+use InvalidArgumentException;
+
+use function Illuminate\Filesystem\join_paths;
+
+class Stub
+{
+    /**
+     * @var bool
+     */
+    private $teams;
+
+    /**
+     * @var 'blog' | 'podcast' | 'phone-book'
+     */
+    private $template;
+
+    /**
+     * @var string
+     */
+    private $basePath;
+
+    /**
+     * @var string
+     */
+    private $controllerType;
+
+    /**
+     * @var array<string, string[]>
+     */
+    private static array $modelNames = [
+        'blog' => ['Post', 'Comment'],
+        'podcast' => ['Podcast', 'Episode', 'Genre'],
+        'phone-book' => ['Person', 'Business', 'Phone', 'Address'],
+    ];
+
+    public function __construct(string $template, string $controllerType, bool $hasTeams)
+    {
+        $this->teams = $hasTeams;
+        $this->template = $template;
+        $this->controllerType = $controllerType;
+        $this->basePath = join_paths(dirname(__DIR__, 2), 'stubs', 'kickstart', $template);
+    }
+
+    /**
+     * @return false|string
+     *
+     * @throws InvalidArgumentException
+     */
+    public function content()
+    {
+        return str_replace(
+            '{{ controllers }}',
+            $this->controllerContent(),
+            file_get_contents($this->draftPath()),
+        );
+    }
+
+    /**
+     * @return 'none' | 'empty' | 'api' | 'web'
+     *
+     * @throws InvalidArgumentException
+     */
+    public function controllerType()
+    {
+        throw_unless(
+            in_array($this->controllerType, ['none', 'empty', 'api', 'web']),
+            InvalidArgumentException::class,
+            "[{$this->controllerType}] is not a valid controller type"
+        );
+
+        return $this->controllerType;
+    }
+
+    public function displayName()
+    {
+        return str($this->template())->replace('-', ' ')->title()->toString();
+    }
+
+    /**
+     * @return string
+     */
+    public function draftPath()
+    {
+        return $this->teams
+            ? join_paths($this->basePath, 'draft-with-teams.yaml.stub')
+            : join_paths($this->basePath, 'draft.yaml.stub');
+    }
+
+    /**
+     * @return string[]
+     *
+     * @throws InvalidArgumentException
+     */
+    public function modelNames()
+    {
+        return self::$modelNames[$this->template()];
+    }
+
+    /**
+     * @return string
+     */
+    public function seederPath()
+    {
+        return join_paths($this->basePath, 'Seeder.php.stub');
+    }
+
+    /**
+     * @return string
+     *
+     * @throws InvalidArgumentException
+     */
+    public function template()
+    {
+        static $validated;
+
+        $template = $this->template;
+
+        if ($validated) {
+            return $template;
+        }
+
+        throw_unless(
+            in_array($template, ['blog', 'podcast', 'phone-book']),
+            InvalidArgumentException::class,
+            "[{$template}] is not listed as a valid kickstart template"
+        );
+
+        $expectedStubFiles = [
+            'draft.yaml.stub',
+            'draft-with-teams.yaml.stub',
+            'Seeder.php.stub',
+        ];
+
+        foreach ($expectedStubFiles as $stubFile) {
+            $stubPath = join_paths($this->basePath, $stubFile);
+
+            throw_unless(
+                file_exists($stubPath),
+                InvalidArgumentException::class,
+                "The [{$stubFile}] stub file does not exist"
+            );
+        }
+
+        $validated = true;
+
+        return $template;
+    }
+
+    /**
+     * @return string
+     *
+     * @throws InvalidArgumentException
+     */
+    private function controllerContent()
+    {
+        if ($this->controllerType() === 'empty') {
+            return $this->emptyControllersContent();
+        }
+
+        if ($this->controllerType() === 'api') {
+            return $this->apiControllersContent();
+        }
+
+        if ($this->controllerType() === 'web') {
+            return $this->webControllersContent();
+        }
+
+        return '';
+    }
+
+    /**
+     * @return string
+     */
+    private function emptyControllersContent()
+    {
+        $result = 'controllers:'.PHP_EOL;
+
+        foreach ($this->modelNames() as $model) {
+            $result .= "  {$model}:".PHP_EOL;
+            $result .= '    resource: none'.PHP_EOL;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return string
+     */
+    private function apiControllersContent()
+    {
+        $result = 'controllers:'.PHP_EOL;
+        foreach ($this->modelNames() as $model) {
+            $pluralResource = str($model)->lower()->plural();
+
+            $result .= "  {$model}:".PHP_EOL;
+            $result .= '    resource: api'.PHP_EOL;
+            $result .= '    index:'.PHP_EOL;
+            $result .= "        resource: 'paginate:{$pluralResource}'".PHP_EOL;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return string
+     */
+    private function webControllersContent()
+    {
+        $result = 'controllers:'.PHP_EOL;
+        foreach ($this->modelNames() as $model) {
+            $result .= "  {$model}:".PHP_EOL;
+            $result .= '    resource'.PHP_EOL;
+        }
+
+        return $result;
+    }
+}

--- a/stubs/kickstart/blog/Seeder.php.stub
+++ b/stubs/kickstart/blog/Seeder.php.stub
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\Comment;
+use App\Models\Post;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Lottery;
+
+class KickstartSeeder extends Seeder
+{
+    public static int $userCount = 10;
+    public static int $postCount = 20;
+    public static int $commentCount = 5;
+
+    public function run(): void
+    {
+        DB::getSchemaBuilder()->withoutForeignKeyConstraints($this->seedPosts(...));
+    }
+
+    private function seedPosts(): void
+    {
+        foreach ($this->users() as $user) {
+            Post::factory(static::$postCount)
+                ->for($user)
+                ->has(Comment::factory(static::$commentCount))
+                ->sequence(function () {
+                    return Lottery::odds(1/3)
+                        ->winner(fn () => ['published_at' => now()])
+                        ->loser(fn () => ['published_at' => null])
+                        ->choose();
+                })
+                ->sequence(array_filter([
+                    'team_id' => rescue(fn () => $user->teams->random()->getKey(), report: false),
+                ]))
+                ->create();
+        }
+    }
+
+    private function users(): EloquentCollection
+    {
+        $users = User::query()
+            ->take(static::$userCount)
+            ->get();
+
+        if ($users->isNotEmpty()) {
+            return $users;
+        }
+
+        $userTeamQualifies = fn () => class_exists(Team::class)
+            && method_exists(User::class, 'teams')
+            && rescue(fn () => Arr::has(Team::factory()->raw(), ['name', 'user_id', 'personal_team']), report: false);
+
+        return EloquentCollection::wrap(
+            User::factory(static::$userCount)
+                ->when($userTeamQualifies, function ($factory) {
+                    return $factory->has(Team::factory()->state(fn (array $attributes, User $user) => [
+                        'name' => $user->name ? "{$user->name}'s Team" : 'Personal Team',
+                        'user_id' => $user->getKey(),
+                        'personal_team' => true,
+                    ]));
+                })
+                ->create()
+        );
+    }
+}

--- a/stubs/kickstart/blog/draft-with-teams.yaml.stub
+++ b/stubs/kickstart/blog/draft-with-teams.yaml.stub
@@ -1,0 +1,26 @@
+# Beginner difficulty
+# Blueprint documentation: https://blueprint.laravelshift.com
+kickstart-template: blog
+
+models:
+  Post:
+    title: string index
+    content: text
+    published_at: timestamp nullable
+    user_id: unsignedBigInteger nullable foreign:users
+    team_id: unsignedBigInteger nullable foreign:teams
+    timestamps: true
+    relationships:
+      belongsTo: User, Team
+      hasMany: Comment
+
+  Comment:
+    body: text
+    timestamps: true
+    post_id: unsignedBigInteger foreign:posts
+    relationships:
+      belongsTo: Post
+
+{{ controllers }}
+
+seeders: Post, Comment

--- a/stubs/kickstart/blog/draft.yaml.stub
+++ b/stubs/kickstart/blog/draft.yaml.stub
@@ -1,0 +1,25 @@
+# Beginner difficulty
+# Blueprint documentation: https://blueprint.laravelshift.com
+kickstart-template: blog
+
+models:
+  Post:
+    title: string index
+    content: text
+    published_at: timestamp nullable
+    user_id: unsignedBigInteger nullable foreign:users
+    timestamps: true
+    relationships:
+      belongsTo: User
+      hasMany: Comment
+
+  Comment:
+    body: text
+    timestamps: true
+    post_id: unsignedBigInteger foreign:posts
+    relationships:
+      belongsTo: Post
+
+{{ controllers }}
+
+seeders: Post, Comment

--- a/stubs/kickstart/phone-book/Seeder.php.stub
+++ b/stubs/kickstart/phone-book/Seeder.php.stub
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\Address;
+use App\Models\Business;
+use App\Models\Person;
+use App\Models\Phone;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class KickstartSeeder extends Seeder
+{
+    public const INDUSTRIES = [
+        'technology',
+        'healthcare',
+        'finance',
+        'retail',
+        'manufacturing',
+        'education',
+        'hospitality',
+        'construction',
+        'transportation',
+    ];
+
+    public static int $userCount = 10;
+    public static int $phoneCount = 2;
+    public static int $peopleCount = 10;
+    public static int $businessCount = 10;
+
+    private EloquentCollection $phoneables;
+    private EloquentCollection $addressables;
+
+    public function run(): void
+    {
+        $this->phoneables = EloquentCollection::make();
+        $this->addressables = EloquentCollection::make();
+
+        DB::getSchemaBuilder()->withoutForeignKeyConstraints(function () {
+            $this->seedPeople();
+            $this->seedBusinesses();
+            $this->seedAddresses();
+            $this->seedPhones();
+        });
+    }
+
+    private function seedPeople(): void
+    {
+        foreach ($this->users() as $user) {
+            $this->seedPerson($user);
+        }
+
+        Collection::times(static::$peopleCount, fn () => $this->seedPerson());
+    }
+
+    private function seedBusinesses(): void
+    {
+        $businesses = EloquentCollection::wrap(
+            Business::factory(static::$businessCount)
+                ->sequence(function () {
+                    return array_filter([
+                        'name' => fake()->unique()->company(),
+                        'industry' => Arr::random(self::INDUSTRIES),
+                        'team_id' => rescue(fn () => Team::inRandomOrder()->first()->getKey(), report: false),
+                    ]);
+                })
+                ->create()
+        );
+
+        if (method_exists($businesses->first(), 'team')) {
+            $businesses->count() && $businesses->loadMissing('team');
+        }
+
+        $this->phoneables = $this->phoneables->merge($businesses);
+        $this->addressables = $this->addressables->merge($businesses);
+    }
+
+    private function seedPerson(?User $user = null): void
+    {
+        $people = EloquentCollection::wrap(Person::factory()
+            ->when($user, function ($factory, $user) {
+                $team = rescue(fn () => $user->teams->random(), report: false);
+
+                return $factory
+                    ->for($user)
+                    ->when($team, fn ($f) => $f->for($team->getKey()));
+            })
+            ->create()
+        );
+
+        if (method_exists($people->first(), 'team')) {
+            $people->count() && $people->loadMissing('team');
+        }
+
+        $this->phoneables = $this->phoneables->merge($people);
+        $this->addressables = $this->addressables->merge($people);
+    }
+
+    private function seedPhones(): void
+    {
+        foreach ($this->phoneables as $phoneable) {
+            $phones = Phone::factory()
+                ->count(static::$phoneCount)
+                ->sequence(function () {
+                    return Arr::random([
+                        ['number' => fake()->e164PhoneNumber(), 'type' => 'mobile'],
+                        ['number' => fake()->e164PhoneNumber(), 'type' => 'home'],
+                        ['number' => fake()->e164PhoneNumber(), 'type' => 'work'],
+                        ['number' => fake()->e164PhoneNumber(), 'type' => 'fax'],
+                        ['number' => fake()->e164PhoneNumber(), 'type' => 'business'],
+                    ]);
+                })
+                ->create();
+
+            $phoneable->phones()->sync($phones);
+        }
+    }
+
+    private function seedAddresses(): void
+    {
+        foreach ($this->addressables as $addressable) {
+            $addressable->address()->save(
+                Address::factory()->make(array_filter([
+                    'city' => fake()->city(),
+                    'street' => fake()->streetName(),
+                    'state' => Arr::random(['NV', 'CA', 'OR', 'TX', 'UT']),
+                    'zip' => Str::limit(fake()->postcode(), 5, ''),
+                ]))
+            );
+        }
+    }
+
+    private function users(): EloquentCollection
+    {
+        $users = User::query()
+            ->take(static::$userCount)
+            ->get();
+
+        if ($users->isNotEmpty()) {
+            return $users;
+        }
+
+        $userTeamQualifies = fn () => class_exists(Team::class)
+            && method_exists(User::class, 'teams')
+            && rescue(fn () => Arr::has(Team::factory()->raw(), ['name', 'user_id', 'personal_team']), report: false);
+
+        return EloquentCollection::wrap(
+            User::factory(static::$userCount)
+                ->when($userTeamQualifies, function ($factory) {
+                    return $factory->has(Team::factory()->state(fn (array $attributes, User $user) => [
+                        'name' => $user->name ? "{$user->name}'s Team" : 'Personal Team',
+                        'user_id' => $user->getKey(),
+                        'personal_team' => true,
+                    ]));
+                })
+                ->create()
+        );
+    }
+}

--- a/stubs/kickstart/phone-book/draft-with-teams.yaml.stub
+++ b/stubs/kickstart/phone-book/draft-with-teams.yaml.stub
@@ -1,0 +1,49 @@
+# Advanced difficulty
+# Blueprint documentation: https://blueprint.laravelshift.com
+kickstart-template: phone-book
+
+models:
+  Person:
+    name: string
+    email: string index
+    team_id: unsignedBigInteger nullable foreign:teams
+    user_id: unsignedBigInteger nullable foreign:users
+    timestamps: true
+    relationships:
+      belongsTo: User, Team
+      morphOne: Address
+      morphToMany: Phone
+
+  Business:
+    name: string index
+    industry: string
+    team_id: unsignedBigInteger nullable foreign:teams
+    timestamps: true
+    relationships:
+      belongsTo: Team
+      morphOne: Address
+      morphToMany: Phone
+
+  Phone:
+    number: string
+    type: string
+    timestamps: true
+    indexes:
+      - unique: number, type
+    relationships:
+      morphedByMany: Person, Business
+
+  Address:
+    street: string index
+    city: string
+    state: string
+    zip: string index
+    timestamps: true
+    indexes:
+      - unique: addressable_id, addressable_type
+    relationships:
+      morphTo: addressable
+
+{{ controllers }}
+
+seeders: Person, Business, Phone, Address

--- a/stubs/kickstart/phone-book/draft.yaml.stub
+++ b/stubs/kickstart/phone-book/draft.yaml.stub
@@ -1,0 +1,46 @@
+# Advanced difficulty
+# Blueprint documentation: https://blueprint.laravelshift.com
+kickstart-template: phone-book
+
+models:
+  Person:
+    name: string
+    email: string index
+    user_id: unsignedBigInteger nullable foreign:users
+    timestamps: true
+    relationships:
+      belongsTo: User
+      morphOne: Address
+      morphToMany: Phone
+
+  Business:
+    name: string index
+    industry: string
+    timestamps: true
+    relationships:
+      morphOne: Address
+      morphToMany: Phone
+
+  Phone:
+    number: string
+    type: string
+    timestamps: true
+    indexes:
+      - unique: number, type
+    relationships:
+      morphedByMany: Person, Business
+
+  Address:
+    street: string index
+    city: string
+    state: string
+    zip: string index
+    timestamps: true
+    indexes:
+      - unique: addressable_id, addressable_type
+    relationships:
+      morphTo: addressable
+
+{{ controllers }}
+
+seeders: Person, Business, Phone, Address

--- a/stubs/kickstart/podcast/Seeder.php.stub
+++ b/stubs/kickstart/podcast/Seeder.php.stub
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\Episode;
+use App\Models\Genre;
+use App\Models\Podcast;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\GenrePodcast;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
+
+class KickstartSeeder extends Seeder
+{
+    public const GENRES_AVAILABLE = [
+        'technology',
+        'business',
+        'health',
+        'science',
+        'sports',
+        'comedy',
+        'education',
+        'arts',
+        'news',
+        'politics',
+        'history',
+        'music',
+        'tv',
+        'film',
+        'books',
+        'technology',
+        'food',
+        'games',
+        'hobbies',
+        'design',
+    ];
+
+    public static int $userCount = 10;
+    public static int $genreCount = 20;
+    public static int $episodeCount = 5;
+    public static int $podcastCount = 10;
+    public static int $podcastGenreCount = 3;
+
+    private EloquentCollection $genres;
+    private EloquentCollection $podcasts;
+
+    public function run(): void
+    {
+        $this->genres = EloquentCollection::make();
+        $this->podcasts = EloquentCollection::make();
+
+        DB::getSchemaBuilder()->withoutForeignKeyConstraints(function () {
+            $this->seedPodcasts();
+            $this->seedGenres();
+            $this->seedPodcastToGenres();
+        });
+    }
+
+    private function seedPodcasts(): void
+    {
+        foreach ($this->users() as $user) {
+            $this->podcasts = $this->podcasts->concat(
+                EloquentCollection::wrap(
+                    Podcast::factory(static::$podcastCount)
+                        ->has(Episode::factory(static::$episodeCount))
+                        ->create(array_filter([
+                            'team_id' => rescue(fn () => $user->teams->random()->getKey(), report: false),
+                        ]))
+                )
+            );
+        }
+    }
+
+    private function seedGenres(): void
+    {
+        $genresAvailable = self::GENRES_AVAILABLE;
+
+        $this->genres = Genre::factory(self::$genreCount)
+            ->sequence(function () use (&$genresAvailable) {
+                return ['name' => array_shift($genresAvailable)];
+            })
+            ->create();
+    }
+
+    private function seedPodcastToGenres(): void
+    {
+        $this
+            ->podcasts
+            ->flatMap(function (Podcast $podcast) {
+                return $this
+                    ->genres
+                    ->shuffle()
+                    ->take(static::$podcastGenreCount)
+                    ->map(function (Genre $genre) use ($podcast) {
+                        return (object) ['genre_id' => $genre->getKey(), 'podcast_id' => $podcast->getKey()];
+                    })
+                    ->all();
+            })
+            ->chunk(500)
+            ->each(function ($chunk) {
+                $chunk
+                    ->map(fn($p) => (array)$p)
+                    ->whenNotEmpty(function ($chunk) {
+                        GenrePodcast::insert($chunk->toArray());
+                    });
+            });
+    }
+
+    private function users(): EloquentCollection
+    {
+        $users = User::query()
+            ->take(static::$userCount)
+            ->get();
+
+        if ($users->isNotEmpty()) {
+            return $users;
+        }
+
+        $userTeamQualifies = fn () => class_exists(Team::class)
+            && method_exists(User::class, 'teams')
+            && rescue(fn () => Arr::has(Team::factory()->raw(), ['name', 'user_id', 'personal_team']), report: false);
+
+        return EloquentCollection::wrap(
+            User::factory(static::$userCount)
+                ->when($userTeamQualifies, function ($factory) {
+                    return $factory->has(Team::factory()->state(fn (array $attributes, User $user) => array_filter([
+                        'name' => $user->name ? "{$user->name}'s Team" : 'Personal Team',
+                        'user_id' => $user->getKey(),
+                        'personal_team' => true,
+                    ])));
+                })
+                ->create()
+        );
+    }
+}

--- a/stubs/kickstart/podcast/draft-with-teams.yaml.stub
+++ b/stubs/kickstart/podcast/draft-with-teams.yaml.stub
@@ -1,0 +1,42 @@
+# Intermediate difficulty
+# Blueprint documentation: https://blueprint.laravelshift.com
+kickstart-template: podcast
+
+models:
+  Podcast:
+    title: string index
+    description: text
+    team_id: unsignedBigInteger nullable foreign:teams
+    timestamps: true
+    relationships:
+      belongsTo: Team
+      hasMany: Episode
+      belongsToMany: Genre:&GenrePodcast
+
+  Episode:
+    title: string index
+    description: text
+    podcast_id: unsignedBigInteger foreign:podcasts
+    timestamps: true
+    relationships:
+      belongsTo: Podcast
+
+  Genre:
+    name: string index
+    timestamps: true
+    relationships:
+      belongsToMany: Podcast:&GenrePodcast
+
+  GenrePodcast:
+    meta:
+      pivot: true
+      table: genre_podcast
+    genre_id: id
+    podcast_id: id
+    timestamps: false
+    indexes:
+      - unique: genre_id, podcast_id
+
+{{ controllers }}
+
+seeders: Podcast, Episode, Genre

--- a/stubs/kickstart/podcast/draft.yaml.stub
+++ b/stubs/kickstart/podcast/draft.yaml.stub
@@ -1,0 +1,40 @@
+# Intermediate difficulty
+# Blueprint documentation: https://blueprint.laravelshift.com
+kickstart-template: podcast
+
+models:
+  Podcast:
+    title: string index
+    description: text
+    timestamps: true
+    relationships:
+      hasMany: Episode
+      belongsToMany: Genre:&GenrePodcast
+
+  Episode:
+    title: string index
+    description: text
+    podcast_id: unsignedBigInteger foreign:podcasts
+    timestamps: true
+    relationships:
+      belongsTo: Podcast
+
+  Genre:
+    name: string index
+    timestamps: true
+    relationships:
+      belongsToMany: Podcast:&GenrePodcast
+
+  GenrePodcast:
+    meta:
+      pivot: true
+      table: genre_podcast
+    genre_id: id
+    podcast_id: id
+    timestamps: false
+    indexes:
+      - unique: genre_id, podcast_id
+
+{{ controllers }}
+
+seeders: Podcast, Episode, Genre


### PR DESCRIPTION
# Laravel Installer Enhancement: `--kickstart` Option

## Overview
This PR introduces a new `--kickstart` option to the Laravel installer, designed to streamline the initial development process by providing pre-configured application templates.

Since this feature leverages the power of the [laravel-shift/blueprint](https://blueprint.laravelshift.com/) package, the user is up-and-running with a non-trivial, fully functional application in a matter of seconds.

For the common use case where a developer needs to quickly run code to test a feature they're working on, try out a 3rd party library, test a library they're working on, fetch data from a REST API, etc. this option is a extremely convenient!

A few more cases I can think of regarding teaching/learning Laravel, this option:

a. Provides a starting point for more advanced Laravel tutorials
b. Allows teachers to start from scratch in a video tutorial, and cover almost any simple-to-advanced feature very rapidly (the student gets to see every step along the way too)
c. Can be used for specific documentation scenarios
d. The developer might be stuck in the depths of some gnarly code and needs a clean slate to test out some logic they're working on

> It's also worth mentioning that Ruby on Rails is doing something very similar in their [intro video](https://rubyonrails.org/).

---

## Key Features

### Ready-made Templates To Choose From
**Blog Template**:

Example:
```bash
laravel new my-blog --kickstart=blog
```

This is the simplest option to choose from.

2 models are included:
- Post
- Comment

Relationship types included:
- belongsTo
- hasMany

<details>

<summary>Generates the following files:</summary>

_controllers and controller tests [discussed below](#controllers-and-controller-tests-generation)_
```bash
- database/factories/PodcastFactory.php
- database/factories/EpisodeFactory.php
- database/factories/GenreFactory.php
- database/factories/GenrePodcastFactory.php
- database/migrations/<timestamp>_create_podcasts_table.php
- database/migrations/<timestamp>_create_episodes_table.php
- database/migrations/<timestamp>_create_genres_table.php
- database/migrations/<timestamp>_create_genre_podcast_table.php
- app/Models/Podcast.php
- app/Models/Episode.php
- app/Models/Genre.php
- app/Models/GenrePodcast.php
- database/seeders/KickstartSeeder.php
```
</details>

**Podcast Template**:

Example:
```bash
laravel new my-podcast --kickstart=podcast
```

The option gets a little more complex, so it's an 'intermediate' option.

3 standard models, and 1 pivot model, are included:
- Podcast
- Episode
- Genre
- GenrePodcast

Relationship types included:
- belongsTo
- hasMany
- belongsToMany

<details>

<summary>Generates the following files:</summary>

_controllers and controller tests [discussed below](#controllers-and-controller-tests-generation)_
```bash
- database/factories/PodcastFactory.php
- database/factories/EpisodeFactory.php
- database/factories/GenreFactory.php
- database/factories/GenrePodcastFactory.php
- database/migrations/<timestamp>_create_podcasts_table.php
- database/migrations/<timestamp>_create_episodes_table.php
- database/migrations/<timestamp>_create_genres_table.php
- database/migrations/<timestamp>_create_genre_podcast_table.php
- app/Models/Podcast.php
- app/Models/Episode.php
- app/Models/Genre.php
- app/Models/GenrePodcast.php
- database/seeders/KickstartSeeder.php
- app/Http/Requests/PodcastStoreRequest.php
- app/Http/Requests/PodcastUpdateRequest.php
- app/Http/Requests/EpisodeStoreRequest.php
- app/Http/Requests/EpisodeUpdateRequest.php
- app/Http/Requests/GenreStoreRequest.php
- app/Http/Requests/GenreUpdateRequest.php
- app/Http/Resources/PodcastCollection.php
- app/Http/Resources/PodcastResource.php
- app/Http/Resources/EpisodeCollection.php
- app/Http/Resources/EpisodeResource.php
- app/Http/Resources/GenreCollection.php
- app/Http/Resources/GenreResource.php
```
</details>

**Phone Book Template**:

Example:
```bash
laravel new my-phone-book --kickstart=phone-book
```

This is the most advanced option, based on its more complex Eloquent relationships.

4 standard Eloquent models are included:
- Person
- Business
- Phone
- Address

Relationship types included:
- belongsTo
- onetoMany Polymorphic
- manyToMany Polymorphic

<details>

<summary>Generates the following files:</summary>

_controllers and controller tests [discussed below](#controllers-and-controller-tests-generation)_
```bash
- database/factories/PersonFactory.php
- database/factories/BusinessFactory.php
- database/factories/PhoneFactory.php
- database/factories/AddressFactory.php
- database/migrations/2024_12_26_075242_create_people_table.php
- database/migrations/2024_12_26_075243_create_businesses_table.php
- database/migrations/2024_12_26_075244_create_phones_table.php
- database/migrations/2024_12_26_075245_create_addresses_table.php
- database/migrations/2024_12_26_075246_create_phoneables_table.php
- app/Models/Person.php
- app/Models/Business.php
- app/Models/Phone.php
- app/Models/Address.php
- database/seeders/PersonSeeder.php
- database/seeders/BusinessSeeder.php
- database/seeders/PhoneSeeder.php
- database/seeders/AddressSeeder.php
- app/Http/Requests/PersonStoreRequest.php
- app/Http/Requests/PersonUpdateRequest.php
- app/Http/Requests/BusinessStoreRequest.php
- app/Http/Requests/BusinessUpdateRequest.php
- app/Http/Requests/PhoneStoreRequest.php
- app/Http/Requests/PhoneUpdateRequest.php
- app/Http/Requests/AddressStoreRequest.php
- app/Http/Requests/AddressUpdateRequest.php
- app/Http/Resources/PersonCollection.php
- app/Http/Resources/PersonResource.php
- app/Http/Resources/BusinessCollection.php
- app/Http/Resources/BusinessResource.php
- app/Http/Resources/PhoneCollection.php
- app/Http/Resources/PhoneResource.php
- app/Http/Resources/AddressCollection.php
- app/Http/Resources/AddressResource.php
```
</details>

### Controllers and Controller Tests Generation

The user will have the option to select which 'controller types' they'd like to generate.

Users can choose one of the following controller generation options:
- Web Resource Controllers (for traditional web applications or the Blade stack)
- API Resource Controllers (REST API focused applications)
- No Controllers (Perfect for Livewire/Inertia.js applications)
- Empty Controllers (For custom implementations)

When reaching this stage in the installation process, the most appropriate controller type will be selected (by default) based on the choices the user makes up to that point.

## Implementation Notes
- Follows existing coding style/type-hint conventions
- Minimal core installer modification
- Error handling that's consistent with how the installer already works
- Controller/component code generation for Livewire and Inertia are coming to the laravel-shift/blueprint package soon. Once it is, I'll be planning to add them to this feature as well.

Cheers and Merry Xmas to everyone!