### PR TITLE
Add `--target` option to specify Laravel version to install

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -42,7 +42,8 @@ class NewCommand extends Command
             ->setName('new')
             ->setDescription('Create a new Laravel application')
             ->addArgument('name', InputArgument::REQUIRED)
-            ->addOption('dev', null, InputOption::VALUE_NONE, 'Installs the latest "development" release')
+            ->addOption('dev', null, InputOption::VALUE_NONE, 'Installs the latest "development" release. Cannot be used with --target')
+            ->addOption('target', null, InputOption::VALUE_OPTIONAL, 'Installs the specified version of Laravel. Cannot be used with --dev')
             ->addOption('git', null, InputOption::VALUE_NONE, 'Initialize a Git repository')
             ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'The branch that should be created for a new repository', $this->defaultBranch())
             ->addOption('github', null, InputOption::VALUE_OPTIONAL, 'Create a new repository on GitHub', false)
@@ -190,6 +191,7 @@ class NewCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $this->validateDevAndTargetOptions($input);
         $this->validateDatabaseOption($input);
         $this->validateStackOption($input);
 
@@ -649,6 +651,21 @@ class NewCommand extends Command
     }
 
     /**
+     * Validate the usage of --dev and --target options.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function validateDevAndTargetOptions(InputInterface $input)
+    {
+        if ($input->getOption('dev') && $input->getOption('target')) {
+            throw new \InvalidArgumentException('The --dev and --target options cannot be used together. Please specify only one.');
+        }
+    }
+
+    /**
      * Validate the database driver input.
      *
      * @param  \Symfony\Components\Console\Input\InputInterface
@@ -882,6 +899,10 @@ class NewCommand extends Command
     {
         if ($input->getOption('dev')) {
             return 'dev-master';
+        }
+
+        if ($input->getOption('target')) {
+            return $input->getOption('target');
         }
 
         return '';

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -385,21 +385,6 @@ class NewCommand extends Command
     }
 
     /**
-     * Determine if the application is using Laravel 11 or newer.
-     *
-     * @param  string  $directory
-     * @return bool
-     */
-    public function usingLaravelVersionOrNewer(int $usingVersion, string $directory): bool
-    {
-        $version = json_decode(file_get_contents($directory.'/composer.json'), true)['require']['laravel/framework'];
-        $version = str_replace('^', '', $version);
-        $version = explode('.', $version)[0];
-
-        return $version >= $usingVersion;
-    }
-
-    /**
      * Comment the irrelevant database configuration entries for SQLite applications.
      *
      * @param  string  $directory

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -72,17 +72,4 @@ class NewCommandTest extends TestCase
             );
         }
     }
-
-    public function test_on_at_least_laravel_11()
-    {
-        $command = new NewCommand;
-
-        $onLaravel10 = $command->usingLaravelVersionOrNewer(11, __DIR__.'/fixtures/laravel10');
-        $onLaravel11 = $command->usingLaravelVersionOrNewer(11, __DIR__.'/fixtures/laravel11');
-        $onLaravel12 = $command->usingLaravelVersionOrNewer(11, __DIR__.'/fixtures/laravel12');
-
-        $this->assertFalse($onLaravel10);
-        $this->assertTrue($onLaravel11);
-        $this->assertTrue($onLaravel12);
-    }
 }


### PR DESCRIPTION
I've added a `--target` option to allow developers to specify which version of Laravel they want to install. This feature has been frequently requested over the years (see #229 in 2022, #250 in 2023, #229 again in 2023, and https://github.com/laravel/installer/pull/319#issuecomment-2001962089 in 2024).

Recently, I personally encountered the need for this feature when working with a client's server that runs multiple PHP applications that are dependent on PHP 8.1. The version of PHP cannot be changed, and the client is not willing to pay for another server, making it necessary to install Laravel 10 rather than the latest version.

What's the alternative? The documentation doesn't mention any (anymore). As of Laravel 11, documentation on installing with `composer create-project` was removed. Docs is pointing to the laravel installer, which everyone I believe enjoys using.

This solution works well for installing the older Laravel versions like so:
```bash
laravel new example-app --target=^10.0
```

<details>
<summary>Also consider "Docker Installation using Sail"</summary>

The `laravel.build` (sail-server) is also affected by the absence of this feature, since it relies on the Laravel installer behind the scenes. To understand how the script creates a new project with an older Laravel version, you'd need to inspect not just the `laravel.build` script, but also the Laravel installer's code. This adds unnecessary complexity.

"Docker Installation using Sail" is recommended like so:
```bash
curl -s "https://laravel.build/example-app" | bash
```
Older Laravel docs (e.g. see [Docker Installation Using Sail](https://laravel.com/docs/10.x/installation#docker-installation-using-sail)) don't mention that this command installs the latest Laravel version. **This leads to confusion (or is even left unnoticed) when developers expect to install the version they are currently reading about in the documentation.**

I've already prepared a solution for myself (see changes in https://github.com/miclaus/sail-server/pull/2 and https://github.com/miclaus/sail-server/pull/3) for the sail-server that adds a `version` query parameter for passing the `--target` option to the Laravel installer. This change could easily be added for older docs. Together with this PR's feature, the following would be possible for e.g. Laravel 10:
```bash
curl -s "https://laravel.build/example-app?version=10" | bash
```
</details>

---

This PR adds flexibility without altering the default experience, and would be particularly developer-friendly for those working with legacy systems or in resource-constrained environments.

I'm not arguing that it's not the best thing to install older versions of Laravel – I agree. But IRL sometimes we need to work with what we have, and this change would simplify the process a lot.

Please consider this. I'm sure we can figure something out.