### PR TITLE
Add `--target` option to specify Laravel version to install

### DIFF
--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -72,17 +72,4 @@ class NewCommandTest extends TestCase
             );
         }
     }
-
-    public function test_on_at_least_laravel_11()
-    {
-        $command = new NewCommand;
-
-        $onLaravel10 = $command->usingLaravelVersionOrNewer(11, __DIR__.'/fixtures/laravel10');
-        $onLaravel11 = $command->usingLaravelVersionOrNewer(11, __DIR__.'/fixtures/laravel11');
-        $onLaravel12 = $command->usingLaravelVersionOrNewer(11, __DIR__.'/fixtures/laravel12');
-
-        $this->assertFalse($onLaravel10);
-        $this->assertTrue($onLaravel11);
-        $this->assertTrue($onLaravel12);
-    }
 }


### PR DESCRIPTION
I've added a `--target` option to allow developers to specify which version of Laravel they want to install. This feature has been frequently requested over the years (see #229 in 2022, #250 in 2023, #229 again in 2023, and https://github.com/laravel/installer/pull/319#issuecomment-2001962089 in 2024).

Recently, I personally encountered the need for this feature when working with a client's server that runs multiple PHP applications that are dependent on PHP 8.1. The version of PHP cannot be changed, and the client is not willing to pay for another server, making it necessary to install Laravel 10 rather than the latest version.

What's the alternative? The documentation doesn't mention any (anymore). As of Laravel 11, documentation on installing with `composer create-project` was removed. Docs is pointing to the laravel installer, which everyone I believe, myself included, enjoys using.

This PR would allow:
```bash
laravel new example-app --target=^10.0
```

<details>
<summary>Also consider "Docker Installation using Sail"</summary>

The `laravel.build` (sail-server) is also affected by the absence of this feature, since it relies on the Laravel installer behind the scenes. To understand how the script creates a new project with an older Laravel version, you'd need to inspect not just the `laravel.build` script, but also the Laravel installer's code. This adds unnecessary complexity.

"Docker Installation using Sail" is recommended like so:
```bash
curl -s "https://laravel.build/example-app" | bash
```
Older Laravel docs (e.g. see [Docker Installation Using Sail](https://laravel.com/docs/10.x/installation#docker-installation-using-sail)) don't mention that this command installs the latest Laravel version. **This leads to confusion (or is even left unnoticed) when developers expect to install the version they are currently reading about in the documentation.**

I've already prepared a solution for myself (see changes in https://github.com/miclaus/sail-server/pull/2 and https://github.com/miclaus/sail-server/pull/3) for the sail-server that adds a `version` query parameter for passing the `--target` option to the Laravel installer. This change could easily be added for older docs. Together with this PR's feature, the following would be possible for e.g. Laravel 10:
```bash
curl -s "https://laravel.build/example-app?version=10" | bash
```
</details>

---

This PR adds flexibility without altering the default experience, and would be particularly developer-friendly for those working with legacy systems or in resource-constrained environments.

I totally agree that installing the current Laravel version should be recommended. Still, IRL sometimes we need to work with what we have, and this change would simplify the process a lot.

Please consider this. I'm sure we can figure something out.