### PR TITLE
Fix Laravel installer on Windows WSL

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -193,7 +193,7 @@ class NewCommand extends Command
         $this->validateDatabaseOption($input);
         $this->validateStackOption($input);
 
-        $name = mb_rtrim($input->getArgument('name'), '/\\');
+        $name = rtrim($input->getArgument('name'), '/\\');
 
         $directory = $this->getInstallationDirectory($name);
 

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -37,7 +37,7 @@ class NewCommandTest extends TestCase
         $this->assertFileExists($scaffoldDirectory.'/.env');
     }
 
-    public function test_it_can_chops_trailing_slash_from_name()
+    public function test_it_can_chop_trailing_slash_from_name()
     {
         if ($this->runOnValetOrHerd('paths') === false) {
             $this->markTestSkipped('Require `herd` or `valet` to resolve `APP_URL` using hostname instead of "localhost".');


### PR DESCRIPTION
Resolves #384 

The missing `mb_trim()` function causes `laravel new` to crash on Windows WSL when running a PHP version lower than 8.4.

Considering the command isn't being used to strip multi-byte characters, `rtrim` should work fine and won't lead to any issues for users who are not yet on PHP 8.4.