### PR TITLE
fix: valet with no paths configured

### DIFF
--- a/src/Concerns/InteractsWithHerdOrValet.php
+++ b/src/Concerns/InteractsWithHerdOrValet.php
@@ -13,11 +13,13 @@ trait InteractsWithHerdOrValet
      * @param  string  $directory
      * @return bool
      */
-    public function isParkedOnHerdOrValet(string $directory)
+    public function isParkedOnHerdOrValet(string $directory): bool
     {
         $output = $this->runOnValetOrHerd('paths');
 
-        return $output !== false ? in_array(dirname($directory), json_decode($output)) : false;
+        $decodedOutput = json_decode($output);
+
+        return $decodedOutput !== null && in_array(dirname($directory), $decodedOutput);
     }
 
     /**
@@ -26,7 +28,7 @@ trait InteractsWithHerdOrValet
      * @param  string  $command
      * @return string|false
      */
-    protected function runOnValetOrHerd(string $command)
+    protected function runOnValetOrHerd(string $command): false|string
     {
         foreach (['herd', 'valet'] as $tool) {
             $process = new Process([$tool, $command, '-v']);

--- a/tests/InteractsWithHerOrValetTest.php
+++ b/tests/InteractsWithHerOrValetTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use Laravel\Installer\Console\Concerns\InteractsWithHerdOrValet;
+use PHPUnit\Framework\TestCase;
+
+class InteractsWithHerOrValetTest extends TestCase
+{
+    use InteractsWithHerdOrValet;
+    public function test_isParkedOnHerdOrValet_returns_false_when_output_is_not_json()
+    {
+        $mockProcess = $this->getMockBuilder(\Symfony\Component\Process\Process::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockProcess->method('isSuccessful')->willReturn(true);
+        $mockProcess->method('getOutput')->willReturn('No paths have been registered.');
+
+        $this->assertFalse($this->isParkedOnHerdOrValet('paths'));
+    }
+}


### PR DESCRIPTION
Fixing a bug when using valet with no parked paths, it returns a string of "No paths have been registered." instead of json output. This fix checks the decoded output instead of passing it directly to the in_array function.