### PR TITLE
Add Support for Custom Starter Kits in Laravel Installer

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -107,7 +107,7 @@ class NewCommand extends Command
         }
 
         if ($input->getOption('custom-starter')) {
-            $output->writeln('<fg=blue>INFO</> Your custom starter must be a Composer package of type "project", stored in a public repository (e.g., GitHub, GitLab), and published on Packagist or a private Composer repository.');
+            $output->writeln('<fg=blue>INFO</> Your custom starter must be a Composer package of type "project", stored in a public repository (e.g., GitHub, GitLab), and published on Packagist.');
             $input->setOption('custom_package', $input->getOption('custom-starter'));
         } elseif (! $input->getOption('react') && ! $input->getOption('vue') && ! $input->getOption('livewire')) {
             match (select(
@@ -129,7 +129,7 @@ class NewCommand extends Command
             };
 
             if ($input->getOption('custom_package')) {
-                $output->writeln('<fg=blue>INFO</> Your custom starter must be a Composer package of type "project", stored in a public repository (e.g., GitHub, GitLab), and published on Packagist or a private Composer repository. take this as a reference/example : https://github.com/laravel/react-starter-kit');
+                $output->writeln('<fg=blue>INFO</> Your custom starter must be a Composer package of type "project", stored in a public repository (e.g., GitHub, GitLab), and published on Packagist. take this as a reference/example : https://github.com/laravel/react-starter-kit');
 
                 $input->setOption('custom_package', text(
                     label: 'Enter the Composer package name (e.g., vendor/package):',
@@ -252,8 +252,6 @@ class NewCommand extends Command
                 }
             }
         }
-
-
 
         $commands = [
             $createProjectCommand,


### PR DESCRIPTION
## **Description:**  
This PR introduces a **"Custom Starter"** option in the Laravel Installer, allowing users to install a Laravel project using their own **custom Composer package** as a template.  

## **What’s Changed?**  
- Added **"Custom Starter"** to the starter kit selection.  
- Prompts users to enter a **Composer package name** (e.g., `vendor/package`).  
- Displays an **info message** explaining that the package must be:  
  - A **Composer package of type `project`**  
  - **Stored in a public repository** (e.g., GitHub, GitLab)  
  - **Published on Packagist**  
- Uses the provided package in **`composer create-project`** for installation.  

## **Example Use Case:**  
Let's say a developer forks the **Laravel React Starter Kit** to customize it further, like this:  
- **Forked Repository:** [HichemTab-tech/forked-from-react-starter-kit](https://github.com/HichemTab-tech/forked-from-react-starter-kit)
- **Published Composer Package:** `hichemtab-tech/forked-from-react-starter-kit`  

With this PR, the developer can now **easily install their custom starter kit** using Laravel Installer:  
```sh
laravel new my-app --custom-starter hichemtabtech/forked-from-react-starter-kit
```
This automatically sets up their **customized Laravel + React starter**, just like the official ones!  

## **Why This is Valuable?**  
✅ **Empowers developers** to create and promote their own **custom starter kits**.  
✅ **Perfect for teams** that use a **large, opinionated Laravel template** frequently.  
✅ **Maintains Laravel Installer’s simplicity**, while adding more flexibility.  
✅ **Avoids unnecessary manual setups**, making project bootstrapping faster.  
✅ **Allows users to define their own stack**, for example:  
   - Laravel doesn’t currently have an **official Svelte starter**, but with this, users can create and share one!  
   - Other custom stacks (e.g., Alpine.js, Inertia with a different setup, etc.) become possible.  

➡️ **This gives Laravel developers even more freedom to use the stack they prefer, without losing the Laravel Installer experience.**  

Would love to hear any feedback! 😊









































