### PR TITLE
Add npm option to fix no-interaction installs

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -48,13 +48,13 @@ class NewCommand extends Command
             ->addOption('github', null, InputOption::VALUE_OPTIONAL, 'Create a new repository on GitHub', false)
             ->addOption('organization', null, InputOption::VALUE_REQUIRED, 'The GitHub organization to create the new repository for')
             ->addOption('database', null, InputOption::VALUE_REQUIRED, 'The database driver your application will use')
-            ->addOption('npm', null, InputOption::VALUE_NONE, 'Install the NPM dependencies')
             ->addOption('react', null, InputOption::VALUE_NONE, 'Install the React Starter Kit')
             ->addOption('vue', null, InputOption::VALUE_NONE, 'Install the Vue Starter Kit')
             ->addOption('livewire', null, InputOption::VALUE_NONE, 'Install the Livewire Starter Kit')
             ->addOption('workos', null, InputOption::VALUE_NONE, 'Use WorkOS for authentication')
             ->addOption('pest', null, InputOption::VALUE_NONE, 'Install the Pest testing framework')
             ->addOption('phpunit', null, InputOption::VALUE_NONE, 'Install the PHPUnit testing framework')
+            ->addOption('npm', null, InputOption::VALUE_NONE, 'Install and build NPM dependencies')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Forces install even if the directory already exists');
     }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -48,6 +48,7 @@ class NewCommand extends Command
             ->addOption('github', null, InputOption::VALUE_OPTIONAL, 'Create a new repository on GitHub', false)
             ->addOption('organization', null, InputOption::VALUE_REQUIRED, 'The GitHub organization to create the new repository for')
             ->addOption('database', null, InputOption::VALUE_REQUIRED, 'The database driver your application will use')
+            ->addOption('npm', null, InputOption::VALUE_NONE, 'Install the NPM dependencies')
             ->addOption('react', null, InputOption::VALUE_NONE, 'Install the React Starter Kit')
             ->addOption('vue', null, InputOption::VALUE_NONE, 'Install the Vue Starter Kit')
             ->addOption('livewire', null, InputOption::VALUE_NONE, 'Install the Livewire Starter Kit')
@@ -297,9 +298,13 @@ class NewCommand extends Command
                 $output->writeln('');
             }
 
-            $runNpm = confirm(
-                label: 'Would you like to run <options=bold>npm install</> and <options=bold>npm run build</>?'
-            );
+            $runNpm = $input->getOption('npm');
+            
+            if (! $input->getOption('npm') && $input->isInteractive()) {
+                $runNpm = confirm(
+                    label: 'Would you like to run <options=bold>npm install</> and <options=bold>npm run build</>?'
+                );
+            }
 
             if ($runNpm) {
                 $this->runCommands(['npm install', 'npm run build'], $input, $output, workingPath: $directory);


### PR DESCRIPTION
This PR fixes an issue when using the current version of the Laravel installer in a non-interactive command.
Right now, the installer always shows a confirmation prompt asking if the user wants to install the NPM dependencies.

This is a problem when running the installer in a non-interactive way, for example:

```
laravel new no-interaction -n
```

This PR changes this behaviour. If the installer is running in non-interactive mode, the NPM dependencies only get installed when the new `--npm` option gets passed to it.

For example:

```
laravel new no-interaction -n --npm
```