### PR TITLE
Remove sqlite from composer.json when not selected as database

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -385,10 +385,10 @@ class NewCommand extends Command
 
         $this->composer->modify(function (array $content) {
             $content['scripts']['post-create-project-cmd'] = [
-                "@php artisan key:generate --ansi",
-                "@php artisan migrate --ansi"
+                '@php artisan key:generate --ansi',
+                '@php artisan migrate --ansi'
             ];
-    
+
             return $content;
         });
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -386,7 +386,7 @@ class NewCommand extends Command
         $this->composer->modify(function (array $content) {
             $content['scripts']['post-create-project-cmd'] = [
                 '@php artisan key:generate --ansi',
-                '@php artisan migrate --ansi'
+                '@php artisan migrate --ansi',
             ];
 
             return $content;

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -383,6 +383,15 @@ class NewCommand extends Command
             return;
         }
 
+        $this->composer->modify(function (array $content) {
+            $content['scripts']['post-create-project-cmd'] = [
+                "@php artisan key:generate --ansi",
+                "@php artisan migrate --ansi"
+            ];
+    
+            return $content;
+        });
+
         // Any commented database configuration options should be uncommented when not on SQLite...
         $this->uncommentDatabaseConfiguration($directory);
 


### PR DESCRIPTION
If we choose anything else than sqlite as a database, composer post create script is still looking for/creating a sqlite file.
This PR aims to change to behavior when sqlite is not selected

Already reported in #329 
