### PR TITLE
[12.x] Restore the ability to choose a database engine during the installation procedure

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -507,8 +507,6 @@ class NewCommand extends Command
         if ($this->usingStarterKit($input)) {
             // Starter kits will already be migrated in post composer create-project command...
             $migrate = false;
-
-            $input->setOption('database', 'sqlite');
         }
 
         if (! $input->getOption('database') && $input->isInteractive()) {


### PR DESCRIPTION
This PR brings a fix to the #404 issue.

Maybe I'm wrong, but the line removed restores the possibility to choose a database engine during installation procedure.

Tell me if something is missing.