### PR TITLE
Adding PHPUnit option back when no starter kit is selected

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -149,8 +149,7 @@ class NewCommand extends Command
             }
         }
 
-        if (! $input->getOption('phpunit') &&
-            ! $input->getOption('pest')) {
+        if (! $input->getOption('phpunit') && ! $input->getOption('pest')) {
             $input->setOption('pest', select(
                 label: 'Which testing framework do you prefer?',
                 options: ['Pest', 'PHPUnit'],

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -149,17 +149,13 @@ class NewCommand extends Command
             }
         }
 
-        if ($this->usingLaravelStarterKit($input)) {
-            if (! $input->getOption('phpunit') &&
-                ! $input->getOption('pest')) {
-                $input->setOption('pest', select(
-                    label: 'Which testing framework do you prefer?',
-                    options: ['Pest', 'PHPUnit'],
-                    default: 'Pest',
-                ) === 'Pest');
-            }
-        } else {
-            $input->setOption('phpunit', true);
+        if (! $input->getOption('phpunit') &&
+            ! $input->getOption('pest')) {
+            $input->setOption('pest', select(
+                label: 'Which testing framework do you prefer?',
+                options: ['Pest', 'PHPUnit'],
+                default: 'Pest',
+            ) === 'Pest');
         }
     }
 


### PR DESCRIPTION
This PR will add back the functionality that allows a user to select **Pest** when not using a starter kit.

This was originally implemented, but it got removed somewhere along the way.