### PR TITLE
Adding Pest option back in Laravel app and improve pest experience

### DIFF
--- a/stubs/pest/Feature.php
+++ b/stubs/pest/Feature.php
@@ -1,7 +1,0 @@
-<?php
-
-it('returns a successful response', function () {
-    $response = $this->get('/');
-
-    $response->assertStatus(200);
-});

--- a/stubs/pest/Unit.php
+++ b/stubs/pest/Unit.php
@@ -1,5 +1,0 @@
-<?php
-
-test('that true is true', function () {
-    expect(true)->toBeTrue();
-});


### PR DESCRIPTION
This PR will add the `pest` option back to the Laravel installer and run drift in a default Laravel app to convert the PHPunit class-based tests to Pest.

@nunomaduro and I collaborated to create a version that would not require the starter kits to need the `Pest.php` file in the test directory but will init that file and make necessary modifications if the user selects `pest` as their testing option.

I'll do some more testing, and then I'll move this out of Draft mode.