### PR TITLE
[5.x] Only open files in the tests directory when converting to Pest

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -609,7 +609,7 @@ class NewCommand extends Command
 
             file_put_contents("$directory/tests/Pest.php", $contents);
 
-            $directoryIterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($directory));
+            $directoryIterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator("$directory/tests"));
 
             foreach ($directoryIterator as $testFile) {
                 if ($testFile->isDir()) {


### PR DESCRIPTION
### Changed

- When it runs the pest installation function, all files in the application's directory will be opened so it removes the `uses(RefreshDatabase::class)` line. But it only needs to open the test files for that.

---

Context: I am working on the [Hotwire Starter Kit](https://github.com/hotwired-laravel/hotwire-starter-kit) and it comes with the [Tailwind CSS Laravel](https://github.com/tonysm/tailwindcss-laravel), which downloads the Tailwind CLI binary, so the installer was dying due to exhausted memory.