### PR TITLE
fix: Starter kits should not ignore the `--database` option

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -509,7 +509,7 @@ class NewCommand extends Command
             $databaseOptions = $this->databaseOptions()
         )->keys()->first();
 
-        if ($this->usingStarterKit($input)) {
+        if (! $input->getOption('database') && $this->usingStarterKit($input)) {
             // Starter kits will already be migrated in post composer create-project command...
             $migrate = false;
 


### PR DESCRIPTION
## Current behaviour
SQLite will be used regardless of using the `--database` option

```bash
laravel new sk-3 --database pgsql
``` 

![CleanShot 2025-06-11 at 10 12 34@2x](https://github.com/user-attachments/assets/db12ca33-80ca-4398-94fe-f6b05385c0c0)


## Expected behaviour
It should use the desired database driver

```bash
laravel new sk-1 --database pgsql
```

![CleanShot 2025-06-11 at 10 02 57@2x](https://github.com/user-attachments/assets/d6e97766-7da7-4c55-b845-6334289026a1)

![CleanShot 2025-06-11 at 10 02 09@2x](https://github.com/user-attachments/assets/469f3bc7-02a8-44b6-b99b-2206cd5f22c2)

## Validation
It validates invalid driver names
```bash
laravel new sk-2 --database invalid-driver-name
```
![CleanShot 2025-06-11 at 10 09 34@2x](https://github.com/user-attachments/assets/c32e11a6-65d7-4ce9-830c-0a7af3e247aa)
