### PR TITLE
feat: add support for multiple package manager

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -834,14 +834,18 @@ class NewCommand extends Command
     protected function getPackageManagerCommands(string $directory, ?string $packageManager = null): array
     {
         if (! $packageManager) {
-            if (file_exists($directory.'/bun.lockb')) {
-                $packageManager = 'bun';
-            } elseif (file_exists($directory.'/pnpm-lock.yaml')) {
-                $packageManager = 'pnpm';
-            } elseif (file_exists($directory.'/yarn.lock')) {
-                $packageManager = 'yarn';
-            } else {
-                $packageManager = 'npm';
+            $lockFiles = [
+                'bun.lockb' => 'bun',
+                'pnpm-lock.yaml' => 'pnpm',
+                'yarn.lock' => 'yarn'
+            ];
+
+            $packageManager = 'npm';
+            foreach ($lockFiles as $file => $manager) {
+                if (file_exists($directory.'/'.$file)) {
+                    $packageManager = $manager;
+                    break;
+                }
             }
         }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -837,7 +837,7 @@ class NewCommand extends Command
             $lockFiles = [
                 'bun.lockb' => 'bun',
                 'pnpm-lock.yaml' => 'pnpm',
-                'yarn.lock' => 'yarn'
+                'yarn.lock' => 'yarn',
             ];
 
             $packageManager = 'npm';

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -853,22 +853,22 @@ class NewCommand extends Command
             'bun' => [
                 'name' => 'bun',
                 'installCommand' => 'bun install',
-                'buildCommand' => 'bun run build'
+                'buildCommand' => 'bun run build',
             ],
             'pnpm' => [
                 'name' => 'pnpm',
                 'installCommand' => 'pnpm install',
-                'buildCommand' => 'pnpm run build'
+                'buildCommand' => 'pnpm run build',
             ],
             'yarn' => [
                 'name' => 'yarn',
                 'installCommand' => 'yarn install',
-                'buildCommand' => 'yarn build'
+                'buildCommand' => 'yarn build',
             ],
             default => [
                 'name' => 'npm',
                 'installCommand' => 'npm install',
-                'buildCommand' => 'npm run build'
+                'buildCommand' => 'npm run build',
             ]
         };
     }


### PR DESCRIPTION
This PR adds support for additional popular Node.js package managers Yarn, Bun, and PNPM. Currently, the Laravel installer only supports npm, which can be restrictive for third-party starter kits that use a different package manager. Supporting these out of the box would make the installer more flexible and developer-friendly.

This also introduces a new --node option, allowing users to default to detected package manager. Passing `--npm` will result into using npm package manger.

This is a non-breaking change.

Thanks.
