### PR TITLE
Add the ability to use a git repo as custom kit

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -243,6 +243,10 @@ class NewCommand extends Command
             if ($this->usingLaravelStarterKit($input) && $input->getOption('workos')) {
                 $createProjectCommand = str_replace(" {$starterKit} ", " {$starterKit}:dev-workos ", $createProjectCommand);
             }
+
+            if (!$this->usingLaravelStarterKit($input) && str_contains($starterKit, '://')) {
+                $createProjectCommand = 'npx degit@latest '.$starterKit.' '.$directory . ' && cd '.$directory . ' && composer install';
+            }
         }
 
         $commands = [

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -245,7 +245,7 @@ class NewCommand extends Command
             }
 
             if (!$this->usingLaravelStarterKit($input) && str_contains($starterKit, '://')) {
-                $createProjectCommand = 'npx degit@latest '.$starterKit.' '.$directory . ' && cd '.$directory . ' && composer install';
+                $createProjectCommand = "git clone --depth=1 ".$starterKit." \"".$directory."\" && cd \"".$directory."\" && rm -rf .git && composer install";
             }
         }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -245,7 +245,7 @@ class NewCommand extends Command
             }
 
             if (!$this->usingLaravelStarterKit($input) && str_contains($starterKit, '://')) {
-                $createProjectCommand = "git clone --depth=1 ".$starterKit." \"".$directory."\" && cd \"".$directory."\" && rm -rf .git && composer install";
+                $createProjectCommand = "npx tiged@latest ".$starterKit." \"".$directory."\" && cd \"".$directory."\" && composer install";
             }
         }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I thought it might be nice to able to use starter kits not published on Packagist. This PR introduces the ability to use a git repo as a starting point when passing the `--using` option:

```bash
laravel new --using https://gitub.com/user/project
```
