### PR TITLE
Support pnpm and yarn package managers

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -310,23 +310,31 @@ class NewCommand extends Command
                 $output->writeln('');
             }
 
+            $packageInstall = "npm install";
+
+            if (file_exists($directory.'/pnpm-lock.yaml')) {
+                $packageInstall = "pnpm install";
+            } else if (file_exists($directory.'/yarn.lock')) {
+                $packageInstall = "yarn install";
+            }
+
             $runNpm = $input->getOption('npm');
 
             if (! $input->getOption('npm') && $input->isInteractive()) {
                 $runNpm = confirm(
-                    label: 'Would you like to run <options=bold>npm install</> and <options=bold>npm run build</>?'
+                    label: 'Would you like to run <options=bold>'.$packageInstall.'</> and <options=bold>npm run build</>?'
                 );
             }
 
             if ($runNpm) {
-                $this->runCommands(['npm install', 'npm run build'], $input, $output, workingPath: $directory);
+                $this->runCommands([$packageInstall, 'npm run build'], $input, $output, workingPath: $directory);
             }
 
             $output->writeln("  <bg=blue;fg=white> INFO </> Application ready in <options=bold>[{$name}]</>. You can start your local development using:".PHP_EOL);
             $output->writeln('<fg=gray>➜</> <options=bold>cd '.$name.'</>');
 
             if (! $runNpm) {
-                $output->writeln('<fg=gray>➜</> <options=bold>npm install && npm run build</>');
+                $output->writeln('<fg=gray>➜</> <options=bold>'.$packageInstall.' && npm run build</>');
             }
 
             if ($this->isParkedOnHerdOrValet($directory)) {


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I have a couple starter kits where I use `pnpm`. I thought it might be nice if the installer could detect lock files and use the appropriate package manager for the starter kit. If none is detected, it maintains the default behavior of using `npm`. I threw in support for `yarn` as it felt incomplete without it.
