### PR TITLE
Don't pass --no-ansi to rm, properly check if output is a TTY

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -908,7 +908,7 @@ class NewCommand extends Command
     {
         if (! $output->isDecorated()) {
             $commands = array_map(function ($value) {
-                if (Str::startsWith($value, ['chmod', 'git', $this->phpBinary().' ./vendor/bin/pest'])) {
+                if (Str::startsWith($value, ['chmod', 'rm', 'git', $this->phpBinary().' ./vendor/bin/pest'])) {
                     return $value;
                 }
 
@@ -918,7 +918,7 @@ class NewCommand extends Command
 
         if ($input->getOption('quiet')) {
             $commands = array_map(function ($value) {
-                if (Str::startsWith($value, ['chmod', 'git', $this->phpBinary().' ./vendor/bin/pest'])) {
+                if (Str::startsWith($value, ['chmod', 'rm', 'git', $this->phpBinary().' ./vendor/bin/pest'])) {
                     return $value;
                 }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -928,7 +928,7 @@ class NewCommand extends Command
 
         $process = Process::fromShellCommandline(implode(' && ', $commands), $workingPath, $env, null, null);
 
-        if ('\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {
+        if (Process::isTtySupported()) {
             try {
                 $process->setTty(true);
             } catch (RuntimeException $e) {


### PR DESCRIPTION
**Don't pass --no-ansi to rm**

When --force is used, rm is part of $commands.

rm something --no-ansi succeeds on macOS but fails on Linux.

---

**Properly check if output is a TTY**

This now matches the check setTty() does.

Previously we were only checking the directory separator
and that /dev/tty exists and is readable.

isTtySupported() checks if /dev/tty is *writable* and more
importantly that STDOUT itself is a TTY.

Simply running `laravel new --stuff foo | head` would produce TTY warns
on systems where /dev/tty exists just fine and only stdout is piped.
