### PR TITLE
Check for new version of installer on `new`

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -255,6 +255,9 @@ class NewCommand extends Command
                 default => '/bin/bash -c "$(curl -fsSL https://php.new/install/linux)"',
             };
 
+            $output->writeln('');
+            $output->writeln('  To update, run the following command in your terminal:');
+
             $this->confirmUpdateAndContinue($message, $input, $output);
 
             return;

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -237,8 +237,8 @@ class NewCommand extends Command
 
         if ($isHerd) {
             return $this->confirmUpdateAndContinue(
-                "To update, open <options=bold>Herd</> > <options=bold>Settings</> > <options=bold>PHP</> > <options=bold>Laravel Installer</> "
-                    ."and click the <options=bold>\"Update\"</> button.",
+                'To update, open <options=bold>Herd</> > <options=bold>Settings</> > <options=bold>PHP</> > <options=bold>Laravel Installer</> '
+                    .'and click the <options=bold>"Update"</> button.',
                 $input,
                 $output
             );
@@ -246,14 +246,14 @@ class NewCommand extends Command
 
         if ($isHerdLite) {
             $message = match(PHP_OS_FAMILY) {
-                'Windows' => "Set-ExecutionPolicy Bypass -Scope Process -Force; "
-                    ."[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; "
+                'Windows' => 'Set-ExecutionPolicy Bypass -Scope Process -Force; '
+                    .'[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; '
                     ."iex ((New-Object System.Net.WebClient).DownloadString('https://php.new/install/windows'))",
                 'Darwin' => '/bin/bash -c "$(curl -fsSL https://php.new/install/mac)"',
                 default => '/bin/bash -c "$(curl -fsSL https://php.new/install/linux)"',
             };
 
-           return $this->confirmUpdateAndContinue($message, $input, $output);
+            return $this->confirmUpdateAndContinue($message, $input, $output);
         }
 
         if (confirm(label: 'Would you like to update now?')) {
@@ -272,20 +272,20 @@ class NewCommand extends Command
      */
     protected function confirmUpdateAndContinue(string $message, InputInterface $input, OutputInterface $output): void
     {
-            $output->writeln("");
-            $output->writeln("  {$message}");
+        $output->writeln("");
+        $output->writeln("  {$message}");
 
-            $updated = confirm(
-                label: 'Would you like to update now?',
-                yes: 'I have updated',
-                no: 'Not now',
-            );
+        $updated = confirm(
+            label: 'Would you like to update now?',
+            yes: 'I have updated',
+            no: 'Not now',
+        );
 
-            if (!$updated) {
-                return;
-            }
+        if (!$updated) {
+            return;
+        }
 
-            $this->proxyLaravelNew($input, $output);
+        $this->proxyLaravelNew($input, $output);
     }
 
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -307,6 +307,7 @@ class NewCommand extends Command
 
         if ($httpCode === 304 && $cacheExists) {
             touch($cachedPath);
+            
             return file_get_contents($cachedPath);
         }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -288,7 +288,6 @@ class NewCommand extends Command
         $this->proxyLaravelNew($input, $output);
     }
 
-
     /**
      * Proxy the command to the globally installed Laravel Installer.
      *

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -236,12 +236,14 @@ class NewCommand extends Command
         $isHerdLite = str_contains($laravelInstallerPath, DIRECTORY_SEPARATOR.'herd-lite'.DIRECTORY_SEPARATOR);
 
         if ($isHerd) {
-            return $this->confirmUpdateAndContinue(
+            $this->confirmUpdateAndContinue(
                 'To update, open <options=bold>Herd</> > <options=bold>Settings</> > <options=bold>PHP</> > <options=bold>Laravel Installer</> '
                     .'and click the <options=bold>"Update"</> button.',
                 $input,
                 $output
             );
+
+            return;
         }
 
         if ($isHerdLite) {
@@ -253,7 +255,9 @@ class NewCommand extends Command
                 default => '/bin/bash -c "$(curl -fsSL https://php.new/install/linux)"',
             };
 
-            return $this->confirmUpdateAndContinue($message, $input, $output);
+            $this->confirmUpdateAndContinue($message, $input, $output);
+
+            return;
         }
 
         if (confirm(label: 'Would you like to update now?')) {
@@ -295,7 +299,7 @@ class NewCommand extends Command
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @return void
      */
-    protected function proxyLaravelNew(InputInterface $input, OutputInterface $output)
+    protected function proxyLaravelNew(InputInterface $input, OutputInterface $output): void
     {
         $output->writeln('');
         $this->runCommands(['laravel '.$input], $input, $output, workingPath: getcwd());

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -307,7 +307,7 @@ class NewCommand extends Command
 
         if ($httpCode === 304 && $cacheExists) {
             touch($cachedPath);
-            
+
             return file_get_contents($cachedPath);
         }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -16,7 +16,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
+use Throwable;
 
+use function Illuminate\Filesystem\join_paths;
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\select;
 use function Laravel\Prompts\text;
@@ -86,6 +88,8 @@ class NewCommand extends Command
   |______\__,_|_|  \__,_| \_/ \___|_|</>'.PHP_EOL.PHP_EOL);
 
         $this->ensureExtensionsAreAvailable($input, $output);
+
+        $this->checkForUpdate($input, $output);
 
         if (! $input->getArgument('name')) {
             $input->setArgument('name', text(
@@ -197,6 +201,122 @@ class NewCommand extends Command
         throw new \RuntimeException(
             sprintf('The following PHP extensions are required but are not installed: %s', $missingExtensions->join(', ', ', and '))
         );
+    }
+
+    /**
+     * Check for newer version of the installer package.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
+     */
+    protected function checkForUpdate(InputInterface $input, OutputInterface $output)
+    {
+        $package = 'laravel/installer';
+        $version = $this->getApplication()->getVersion();
+        $versionData = $this->getLatestVersionData($package);
+
+        if ($versionData === false) {
+            return;
+        }
+
+        $data = json_decode($versionData, true);
+        $latestVersion = ltrim($data['packages'][$package][0]['version'], 'v');
+
+        if (version_compare($version, $latestVersion) !== -1) {
+            return;
+        }
+
+        $output->writeln("  <bg=yellow;fg=black> WARN </> A new version of the Laravel Installer is available. You have version {$version} installed, the latest version is {$latestVersion}.");
+
+        $shouldUpdate = confirm(
+            label: 'Would you like to update now?'
+        );
+
+        if ($shouldUpdate) {
+            $this->runCommands(['composer global update laravel/installer'], $input, $output);
+            $output->writeln('');
+        }
+    }
+
+    /**
+     * Get the latest version of the installer package from Packagist.
+     *
+     * @param  string  $package
+     * @return string|false
+     */
+    protected function getLatestVersionData(string $package): string|false
+    {
+        $packagePrefix = str_replace('/', '-', $package);
+        $cachedPath = join_paths(sys_get_temp_dir(), $packagePrefix.'-version-check.json');
+        $lastModifiedPath = join_paths(sys_get_temp_dir(), $packagePrefix.'-last-modified');
+
+        $cacheExists = file_exists($cachedPath);
+        $lastModifiedExists = file_exists($lastModifiedPath);
+
+        $cacheLastWrittenAt = $cacheExists ? filemtime($cachedPath) : 0;
+        $lastModifiedResponse = $lastModifiedExists ? file_get_contents($lastModifiedPath) : null;
+
+        if ($cacheLastWrittenAt > time() - 86400) {
+            // Cache is less than 24 hours old, use it
+            return file_get_contents($cachedPath);
+        }
+
+        $curl = curl_init();
+
+        $headers = ['User-Agent: Laravel Installer'];
+
+        if ($lastModifiedResponse) {
+            $headers[] = "If-Modified-Since: {$lastModifiedResponse}";
+        }
+
+        curl_setopt_array($curl, [
+            CURLOPT_URL => "https://repo.packagist.org/p2/{$package}.json",
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HEADER => true,
+            CURLOPT_HTTPHEADER => $headers,
+            CURLOPT_TIMEOUT => 10,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_SSL_VERIFYPEER => true,
+        ]);
+
+        try {
+            $response = curl_exec($curl);
+            $httpCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+            $headerSize = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
+            $error = curl_error($curl);
+            curl_close($curl);
+        } catch (Throwable $e) {
+            return false;
+        }
+
+        if ($error) {
+            return false;
+        }
+
+        $responseHeaders = substr($response, 0, $headerSize);
+        $result = substr($response, $headerSize);
+
+        $lastModifiedFromResponse = null;
+
+        if (preg_match('/^Last-Modified:\s*(.+)$/mi', $responseHeaders, $matches)) {
+            $lastModifiedFromResponse = trim($matches[1]);
+        }
+
+        file_put_contents($lastModifiedPath, $lastModifiedFromResponse);
+
+        if ($httpCode === 304 && $cacheExists) {
+            touch($cachedPath);
+            return file_get_contents($cachedPath);
+        }
+
+        if ($httpCode === 200 && $result !== false) {
+            file_put_contents($cachedPath, $result);
+
+            return $result;
+        }
+
+        return ($cacheExists) ? file_get_contents($cachedPath) : false;
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -245,7 +245,7 @@ class NewCommand extends Command
         }
 
         if ($isHerdLite) {
-            $message = match(PHP_OS_FAMILY) {
+            $message = match (PHP_OS_FAMILY) {
                 'Windows' => 'Set-ExecutionPolicy Bypass -Scope Process -Force; '
                     .'[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; '
                     ."iex ((New-Object System.Net.WebClient).DownloadString('https://php.new/install/windows'))",
@@ -272,7 +272,7 @@ class NewCommand extends Command
      */
     protected function confirmUpdateAndContinue(string $message, InputInterface $input, OutputInterface $output): void
     {
-        $output->writeln("");
+        $output->writeln('');
         $output->writeln("  {$message}");
 
         $updated = confirm(
@@ -281,7 +281,7 @@ class NewCommand extends Command
             no: 'Not now',
         );
 
-        if (!$updated) {
+        if (! $updated) {
             return;
         }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -228,7 +228,7 @@ class NewCommand extends Command
             return;
         }
 
-        $output->writeln("  <bg=yellow;fg=black> WARN </> A new version of the Laravel installer is available. You have version {$version} installed, the latest version is {$latestVersion}.");
+        $output->writeln("  <bg=yellow;fg=black> WARN </> A new version of the Laravel Installer is available. You have version {$version} installed, the latest version is {$latestVersion}.");
 
         $laravelInstallerPath = (new ExecutableFinder())->find('laravel') ?? '';
         $isHerd = str_contains($laravelInstallerPath, DIRECTORY_SEPARATOR.'Herd'.DIRECTORY_SEPARATOR);
@@ -263,7 +263,7 @@ class NewCommand extends Command
     }
 
     /**
-     * Allow the user to update the Laravel installer and continue.
+     * Allow the user to update the Laravel Installer and continue.
      *
      * @param  string  $message
      * @param  \Symfony\Component\Console\Input\InputInterface  $input
@@ -290,7 +290,7 @@ class NewCommand extends Command
 
 
     /**
-     * Proxy the command to the globally installed Laravel installer.
+     * Proxy the command to the globally installed Laravel Installer.
      *
      * @param  \Symfony\Component\Console\Input\InputInterface  $input
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -228,7 +228,7 @@ class NewCommand extends Command
             return;
         }
 
-        $output->writeln("  <bg=yellow;fg=black> WARN </> A new version of the Laravel Installer is available. You have version {$version} installed, the latest version is {$latestVersion}.");
+        $output->writeln("  <bg=yellow;fg=black> WARN </> A new version of the Laravel installer is available. You have version {$version} installed, the latest version is {$latestVersion}.");
 
         $laravelInstallerPath = (new ExecutableFinder())->find('laravel') ?? '';
         $isHerd = str_contains($laravelInstallerPath, DIRECTORY_SEPARATOR.'Herd'.DIRECTORY_SEPARATOR);


### PR DESCRIPTION
This PR checks for any newer versions of the installer on Packagist and offers to self-update for the user if one exists. 

It only checks Packagist at most once per 24 hours, and sends the `If-Modified-Since` header for maximum caching.