### PR TITLE
Add support for Yarn, PNPM, and Bun in Laravel Installer for better package manager control

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -402,7 +402,6 @@ class NewCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-
         $this->validateDatabaseOption($input);
 
         $name = rtrim($input->getArgument('name'), '/\\');


### PR DESCRIPTION


Thanks to the amazing PR https://github.com/laravel/installer/pull/439  by @ludo237 , I’d like to suggest a slightly different approach to selecting the package manager, allowing developers to choose it in a more explicit and flexible way.

This PR introduces support for Yarn, PNPM, and Bun alongside npm in the Laravel Installer. Developers can now select their preferred package manager via CLI options or an interactive prompt, or skip installation of JS packages entirely.

This approach gives developers direct control over which package manager to use, instead of relying solely on lock file detection (as in the related PR). It improves flexibility while maintaining backward compatibility with npm as the default.


