### PR TITLE
Symfony namespace spelling issue

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -811,7 +811,7 @@ class NewCommand extends Command
     /**
      * Validate the database driver input.
      *
-     * @param  \Symfony\Components\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
      */
     protected function validateDatabaseOption(InputInterface $input)
     {


### PR DESCRIPTION
Symfony uses `Component `(singular) in all its namespace paths. Each component (Console, HttpFoundation, Routing, etc.) is under the `Symfony\Component\ namespace.`
So the first example has a typo—it should be `Component`, not `Components`.
