### PR TITLE
Add Laravel Boost Installation Option

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -178,7 +178,7 @@ class NewCommand extends Command
 
         if (! $input->getOption('boost')) {
             $input->setOption('boost', confirm(
-                label: 'Do you want to install and configure Laravel Boost to improve AI assisted coding?',
+                label: 'Do you want to install Laravel Boost to improve AI assisted coding?',
             ));
         }
     }


### PR DESCRIPTION
### Summary
- Adds a `--boost` option and interactive prompt to install and configure Laravel Boost during app scaffolding.
- Installs Boost via Composer and runs the Boost installer, respecting non‑interactive mode and appends a Composer post‑update script to keep Boost up‑to‑date automatically.
- Interactive: prompts “`Do you want to install and configure Laravel Boost?`” and proceeds on confirmation.

### Backward Compatibility
 - Opt-in only. No changes if `--boost` is omitted and you decline the prompt.

<img width="608" height="392" alt="Screenshot 2025-10-27 at 5 51 09 PM" src="https://github.com/user-attachments/assets/7e59549b-d0c8-4b0c-86f8-11b4083107f3" />
