### PR TITLE
Add Node package manager detection

### DIFF
--- a/src/Enums/NodePackageManager.php
+++ b/src/Enums/NodePackageManager.php
@@ -58,4 +58,20 @@ enum NodePackageManager: string
             self::BUN => ['bun.lock', 'bun.lockb'],
         };
     }
+
+    public function isAvailable(): bool
+    {
+        return (new \Symfony\Component\Process\ExecutableFinder())->find($this->value) !== null;
+    }
+
+    public static function detect(): self
+    {
+        foreach ([self::BUN, self::PNPM, self::YARN, self::NPM] as $pm) {
+            if ($pm->isAvailable()) {
+                return $pm;
+            }
+        }
+
+        return self::NPM;
+    }
 }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -604,7 +604,7 @@ class NewCommand extends Command
             }
         }
 
-        return [NodePackageManager::NPM, false];
+        return [NodePackageManager::detect(), false];
     }
 
     /**

--- a/tests/NodePackageManagerTest.php
+++ b/tests/NodePackageManagerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Laravel\Installer\Console\Tests;
+
+use Laravel\Installer\Console\Enums\NodePackageManager;
+use PHPUnit\Framework\TestCase;
+
+class NodePackageManagerTest extends TestCase
+{
+    public function test_isAvailable_returns_boolean()
+    {
+        foreach (NodePackageManager::cases() as $pm) {
+            $this->assertIsBool($pm->isAvailable());
+        }
+    }
+
+    public function test_detect_returns_valid_package_manager()
+    {
+        $detected = NodePackageManager::detect();
+        $this->assertContains($detected, NodePackageManager::cases());
+    }
+
+    public function test_detect_prefers_faster_package_managers()
+    {
+        $detected = NodePackageManager::detect();
+
+        if (NodePackageManager::BUN->isAvailable()) {
+            $this->assertSame(NodePackageManager::BUN, $detected);
+        } elseif (NodePackageManager::PNPM->isAvailable()) {
+            $this->assertSame(NodePackageManager::PNPM, $detected);
+        } elseif (NodePackageManager::YARN->isAvailable()) {
+            $this->assertSame(NodePackageManager::YARN, $detected);
+        } else {
+            $this->assertSame(NodePackageManager::NPM, $detected);
+        }
+    }
+
+    public function test_npm_is_typically_available()
+    {
+        if (! NodePackageManager::NPM->isAvailable()) {
+            $this->markTestSkipped('npm is not installed.');
+        }
+
+        $this->assertTrue(NodePackageManager::NPM->isAvailable());
+    }
+}


### PR DESCRIPTION
Instead of falling back to NPM, detect and prioritize faster package managers (Bun > PNPM > Yarn) over NPM:

-  Added isAvailable() and detect() methods in the NodePackageManager
-  NewCommand tries to detect the best available package manager instead of defaulting to NPM
-  Added tests/NodePackageManagerTest.php to verify the detection and availability logic.