### PR TITLE
Remove usage of deprecated `curl_close()` function

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -366,7 +366,8 @@ class NewCommand extends Command
             $httpCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
             $headerSize = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
             $error = curl_error($curl);
-            curl_close($curl);
+
+            unset($curl);
         } catch (Throwable $e) {
             return false;
         }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
