### PR TITLE
Use Bun in CI workflow when --bun option is selected

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -899,19 +899,19 @@ class NewCommand extends Command
                 $this->replaceInFile(
                     '- uses: actions/setup-node@v4',
                     '- uses: oven-sh/setup-bun@v1',
-                    $directory . '/.github/workflows/tests.yml',
+                    $directory.'/.github/workflows/tests.yml',
                 );
 
                 $this->replaceInFile(
                     'npm ci',
                     'bun install --frozen-lockfile',
-                    $directory . '/.github/workflows/tests.yml',
+                    $directory.'/.github/workflows/tests.yml',
                 );
 
                 $this->replaceInFile(
                     'npm run build',
                     'bun run build',
-                    $directory . '/.github/workflows/tests.yml',
+                    $directory.'/.github/workflows/tests.yml',
                 );
             }
 


### PR DESCRIPTION
This PR updates the generated GitHub Actions workflow to use Bun when the
`--bun` option is selected during project creation.

### Changes
- Replace `actions/setup-node` with `oven-sh/setup-bun` when Bun is selected
- Use `bun install --frozen-lockfile` instead of `npm ci`
- Use `bun run build` instead of `npm run build`

### Rationale
When creating a Laravel application with the `--bun` option, the generated
project already uses Bun locally, but the default CI workflow still relies
on npm. This change aligns the CI environment with the selected package
manager.

Node-specific configuration is intentionally left untouched to keep the
workflow resilient to future Node version changes.

### Impact
- No changes to default behavior (npm)
- No breaking changes
- Improves consistency for Bun users
