### PR TITLE
Fix Herd/Valet detection based on stored paths

### DIFF
--- a/src/Concerns/InteractsWithHerdOrValet.php
+++ b/src/Concerns/InteractsWithHerdOrValet.php
@@ -19,7 +19,9 @@ trait InteractsWithHerdOrValet
 
         $decodedOutput = json_decode($output);
 
-        return is_array($decodedOutput) && (in_array(dirname($directory), $decodedOutput) || in_array(dirname($directory) . DIRECTORY_SEPARATOR, $decodedOutput));
+        return is_array($decodedOutput) && 
+            (in_array(dirname($directory), $decodedOutput) || 
+             in_array(dirname($directory).DIRECTORY_SEPARATOR, $decodedOutput));
     }
 
     /**


### PR DESCRIPTION
Depending on how paths get stored in Herd or Valet, they might be stored with a trailing slash in the `herd paths` or `valet paths` output. For example:

```
[
    "/Users/marcelpociot/Library/Application Support/Herd/config/valet/Sites",
    "/Users/marcelpociot/Code/",
    "/Users/marcelpociot/Herd/"
]
```

In this case, the `in_array` check would fail, as it would only check for the pathname without a trailing slash.
This fixes the behaviour and ensures that Herd and Valet get detected properly.