### PR TITLE
Single File Components

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -162,7 +162,7 @@ class NewCommand extends Command
                 ! $input->getOption('workos') &&
                 ! $input->getOption('no-authentication')) {
                 $input->setOption('livewire-class-components', ! confirm(
-                    label: 'Would you like to Single File Livewire Components?',
+                    label: 'Would you like to use single-file Livewire components?',
                     default: true,
                 ));
             }


### PR DESCRIPTION
Currently if your environment supports Livewire V4 and you choose "Yes" for Volt, you no longer get Volt. You get Livewire's new "native" Single File Components.

This PR removes the confusing reference to volt which isn't installed for Livewire >= v4. I was struggling to figure out how to get a fresh skeleton up with the new SFComponents so that I could inspect the structure and play around with it a bit. 

A volt component is a single file component, however a single file component is no longer always a volt component.
