### PR TITLE
Change add method with addCommand. Because add is deprecated in symfony/console

### DIFF
--- a/bin/laravel
+++ b/bin/laravel
@@ -8,6 +8,11 @@ if (file_exists(__DIR__.'/../../../autoload.php')) {
 }
 
 $app = new Symfony\Component\Console\Application('Laravel Installer', '5.24.0');
-$app->addCommand(new Laravel\Installer\Console\NewCommand);
+
+if (method_exists($app, 'addCommand')) {
+    $app->addCommand(new Laravel\Installer\Console\NewCommand);
+} else {
+    $app->add(new Laravel\Installer\Console\NewCommand);
+}
 
 $app->run();


### PR DESCRIPTION
here is the deprecated message

@deprecated since Symfony 7.4, use Application::addCommand() instead

they are suggesting to use addCommand method.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
