### PR TITLE
Fix current release version

### DIFF
--- a/bin/laravel
+++ b/bin/laravel
@@ -7,7 +7,7 @@ if (file_exists(__DIR__.'/../../../autoload.php')) {
     require __DIR__.'/../vendor/autoload.php';
 }
 
-$app = new Symfony\Component\Console\Application('Laravel Installer', '5.24.0');
+$app = new Symfony\Component\Console\Application('Laravel Installer', '5.24.2');
 
 if (method_exists($app, 'addCommand')) {
     $app->addCommand(new Laravel\Installer\Console\NewCommand);


### PR DESCRIPTION
Updates the CLI version. The project got tagged with `5.24.1`, but the CLI version was not updated accordingly, so it keeps re-prompting for an update.
Master needs a new tag (`5.24.2`) after merging this.