### PR TITLE
Move boost:install after Node package installation

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -547,10 +547,6 @@ class NewCommand extends Command
                 $this->installPest($directory, $input, $output);
             }
 
-            if ($input->getOption('boost') && ! $input->getOption('no-boost')) {
-                $this->installBoost($directory, $input, $output);
-            }
-
             if ($input->getOption('github') !== false) {
                 $this->pushToGitHub($name, $directory, $input, $output);
                 $output->writeln('');
@@ -578,6 +574,10 @@ class NewCommand extends Command
 
             if ($runPackageManager) {
                 $this->runCommands([$packageManager->installCommand(), $packageManager->buildCommand()], $input, $output, workingPath: $directory);
+            }
+
+            if ($input->getOption('boost') && ! $input->getOption('no-boost')) {
+                $this->installBoost($directory, $input, $output);
             }
 
             if ($input->getOption('boost') && ! $input->getOption('no-boost')) {


### PR DESCRIPTION
Currently `boost:install` runs before the Node package manager install, which means Boost can't detect Node.js packages because they haven't been installed yet. Moving it after the Node install step allows Boost to detect and index Node packages.

### Approach

- Reorder the `installBoost()` call in `execute()` to run after the Node package manager install and build step, right before `configureBoostComposerScript()`