### PR TITLE
Only run post-root-package-install if script exists

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -495,8 +495,6 @@ class NewCommand extends Command
 
         $commands = [
             $createProjectCommand,
-            $composer." run post-root-package-install -d \"$directory\"",
-            $phpBinary." \"$directory/artisan\" key:generate --ansi",
         ];
 
         if ($directory != '.' && $input->getOption('force')) {
@@ -507,11 +505,24 @@ class NewCommand extends Command
             }
         }
 
-        if (PHP_OS_FAMILY != 'Windows') {
-            $commands[] = "chmod 755 \"$directory/artisan\"";
-        }
-
         if (($process = $this->runCommands($commands, $input, $output))->isSuccessful()) {
+            if ($this->hasComposerScript('post-root-package-install', $directory)) {
+                $this->runCommands(
+                    [$composer." run post-root-package-install -d \"$directory\""],
+                    $input,
+                    $output,
+                );
+            }
+
+            $postCreateCommands = [
+                $phpBinary." \"$directory/artisan\" key:generate --ansi",
+            ];
+
+            if (PHP_OS_FAMILY != 'Windows') {
+                $postCreateCommands[] = "chmod 755 \"$directory/artisan\"";
+            }
+
+            $this->runCommands($postCreateCommands, $input, $output);
             if ($name !== '.') {
                 $this->replaceInFile(
                     'APP_URL=http://localhost',
@@ -1113,6 +1124,26 @@ class NewCommand extends Command
 
             return $content;
         });
+    }
+
+    /**
+     * Determine if the given Composer script exists in the application's composer.json.
+     *
+     * @param  string  $script
+     * @param  string  $directory
+     * @return bool
+     */
+    protected function hasComposerScript(string $script, string $directory): bool
+    {
+        $composerJson = $directory.'/composer.json';
+
+        if (! file_exists($composerJson)) {
+            return false;
+        }
+
+        $composer = json_decode(file_get_contents($composerJson), true);
+
+        return isset($composer['scripts'][$script]);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Checks the project's `composer.json` for a `post-root-package-install` script before attempting to run it
- Community starter kits using `--using` that don't define this script no longer cause the installation to fail
- Splits the command chain so `key:generate` and `chmod` still run even if the script is absent

## Test plan
- [ ] Create a project with an official Laravel starter kit (e.g. `--vue`) and verify `post-root-package-install` still runs
- [ ] Create a project with `--using` pointing to a community starter kit without `post-root-package-install` and verify installation completes
- [ ] Create a project without a starter kit and verify normal installation still works

Fixes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)