### PR TITLE
Apply package manager selection to GitHub workflow files

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -556,6 +556,10 @@ class NewCommand extends Command
 
             $this->configureComposerScripts($packageManager);
 
+            if ($packageManager !== NodePackageManager::NPM) {
+                $this->configureGitHubWorkflows($packageManager, $directory);
+            }
+
             if ($input->getOption('pest')) {
                 $output->writeln('');
             }
@@ -1099,6 +1103,32 @@ class NewCommand extends Command
 
             return $content;
         });
+    }
+
+    /**
+     * Configure GitHub workflow files to use the selected package manager.
+     *
+     * @param  NodePackageManager  $packageManager
+     * @param  string  $directory
+     * @return void
+     */
+    protected function configureGitHubWorkflows(NodePackageManager $packageManager, string $directory): void
+    {
+        $workflowFiles = [
+            $directory.'/.github/workflows/tests.yml',
+            $directory.'/.github/workflows/lint.yml',
+        ];
+
+        foreach ($workflowFiles as $file) {
+            if (! file_exists($file)) {
+                continue;
+            }
+
+            $this->replaceInFile('npm install', $packageManager->installCommand(), $file);
+            $this->replaceInFile('npm run build', $packageManager->buildCommand(), $file);
+            $this->replaceInFile('npm run format', $packageManager->runCommand().' format', $file);
+            $this->replaceInFile('npm run lint', $packageManager->runCommand().' lint', $file);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- When using `--pnpm`, `--bun`, or `--yarn`, the `.github/workflows/tests.yml` and `lint.yml` files now use the selected package manager instead of always using npm
- Replaces `npm install`, `npm run build`, `npm run format`, and `npm run lint` with the equivalent commands for the chosen package manager

## Test plan
- [ ] Run `laravel new --vue --pnpm` and verify `.github/workflows/tests.yml` uses `pnpm install` and `pnpm build`
- [ ] Run `laravel new --vue --bun` and verify workflows use `bun install` and `bun run build`
- [ ] Run `laravel new --vue --yarn` and verify workflows use `yarn install` and `yarn build`
- [ ] Run `laravel new --vue` (default npm) and verify workflows remain unchanged
- [ ] Verify `lint.yml` also gets updated with the correct format/lint commands

Fixes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)