### PR TITLE
Remove unsupported formatting tags from confirm prompt

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -562,7 +562,7 @@ class NewCommand extends Command
 
             if (! $runPackageManager && $input->isInteractive()) {
                 $runPackageManager = confirm(
-                    label: 'Would you like to run <options=bold>'.$packageManager->installCommand().'</> and <options=bold>'.$packageManager->buildCommand().'</>?'
+                    label: 'Would you like to run '.$packageManager->installCommand().' and '.$packageManager->buildCommand().'?'
                 );
             }
 


### PR DESCRIPTION
## Summary
- Removes `<options=bold>` Symfony Console formatting tags from the `confirm()` prompt label asking whether to run npm install and build
- Laravel Prompts does not support Symfony Console formatting tags, so they were being rendered literally as `<options=bold>` in the prompt text

## Test plan
- [ ] Run `laravel new` with a starter kit selected and decline to run the package manager initially
- [ ] Verify the confirm prompt displays cleanly without literal `<options=bold>` text
- [ ] Verify the prompt still shows the correct install and build commands

Fixes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)