### PR TITLE
Prevent infinite loop when installer self-update fails

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -315,7 +315,26 @@ class NewCommand extends Command
 
         if (confirm(label: 'Would you like to update now?')) {
             $this->runCommands(['composer global update laravel/installer'], $input, $output);
-            $this->proxyLaravelNew($input, $output);
+
+            // Check the installed version after update to avoid a re-proxy loop
+            // if the update didn't actually install a newer version...
+            $checkProcess = new Process(['composer', 'global', 'show', 'laravel/installer', '--format=json']);
+            $checkProcess->run();
+
+            if ($checkProcess->isSuccessful()) {
+                $installedData = json_decode($checkProcess->getOutput(), true);
+                $installedVersion = ltrim($installedData['versions'][0] ?? $version, 'v');
+
+                if (version_compare($installedVersion, $version) > 0) {
+                    $this->proxyLaravelNew($input, $output);
+
+                    return;
+                }
+            }
+
+            $output->writeln('');
+            $output->writeln('  <bg=yellow;fg=black> WARN </> Unable to update the installer. Continuing with the current version...');
+            $output->writeln('');
         }
     }
 


### PR DESCRIPTION
## Summary
- After running `composer global update laravel/installer`, the installer now checks whether a newer version was actually installed before re-invoking itself
- If the update did not result in a newer version (e.g. due to a Composer constraint issue), the installer warns the user and continues with the current version instead of entering an infinite loop

## Test plan
- [ ] Simulate an outdated installer and accept the update prompt; verify it re-invokes correctly when the update succeeds
- [ ] Simulate an outdated installer where the update command does not change the version; verify it warns and continues instead of looping
- [ ] Verify the update flow still works correctly when installed via Herd (different code path)

Fixes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)