### PR TITLE
Add teams support option to the installer

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -169,6 +169,7 @@ class NewCommand extends Command
 
             if ($this->usingLaravelStarterKit($input) &&
                 ! $input->getOption('no-authentication') &&
+                ! $input->getOption('livewire-class-components') &&
                 ! $input->getOption('teams')) {
                 $input->setOption('teams', confirm(
                     label: 'Would you like to add teams support to your application?',


### PR DESCRIPTION
Starter kits will ship with a `teams` branch variant. This adds the option so users can opt into team support during project creation.

### Usage

```bash
# Via flag
laravel new my-app --react --teams

# Interactive — prompted after choosing a starter kit with authentication
```

### Approach

- Adds a `--teams` CLI flag and an interactive yes/no prompt shown when using a starter kit with authentication
- Resolves the correct starter kit branch (`teams`, `workos-teams`) based on the combination of auth provider and teams selection