### PR TITLE
Escape starter kit argument in shell commands

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -489,10 +489,12 @@ class NewCommand extends Command
         $starterKit = $this->getStarterKit($input);
 
         if ($starterKit) {
-            $createProjectCommand = $composer." create-project {$starterKit} \"{$directory}\" --stability=dev";
+            $escapedStarterKit = escapeshellarg($starterKit);
+
+            $createProjectCommand = $composer." create-project {$escapedStarterKit} \"{$directory}\" --stability=dev";
 
             if ($this->usingLaravelStarterKit($input) && $input->getOption('livewire-class-components')) {
-                $createProjectCommand = str_replace(" {$starterKit} ", " {$starterKit}:dev-components ", $createProjectCommand);
+                $createProjectCommand = str_replace(" {$escapedStarterKit} ", ' '.escapeshellarg($starterKit.':dev-components').' ', $createProjectCommand);
             }
 
             if ($this->usingLaravelStarterKit($input)) {
@@ -504,12 +506,12 @@ class NewCommand extends Command
                 };
 
                 if ($branch) {
-                    $createProjectCommand = str_replace(" {$starterKit} ", " {$starterKit}:{$branch} ", $createProjectCommand);
+                    $createProjectCommand = str_replace(" {$escapedStarterKit} ", ' '.escapeshellarg($starterKit.':'.$branch).' ', $createProjectCommand);
                 }
             }
 
             if (! $this->usingLaravelStarterKit($input) && str_contains($starterKit, '://')) {
-                $createProjectCommand = 'npx tiged@latest '.$starterKit.' "'.$directory.'" && cd "'.$directory.'" && composer install';
+                $createProjectCommand = 'npx tiged@latest '.escapeshellarg($starterKit).' "'.$directory.'" && cd "'.$directory.'" && composer install';
             }
         }
 


### PR DESCRIPTION
## Summary

Wraps the `$starterKit` value with `escapeshellarg()` where it is interpolated into shell commands via `Process::fromShellCommandline()`.

## Changes

The `--using` option value was interpolated directly into shell commands without escaping, while `$directory` in the same lines was already quoted. This change applies `escapeshellarg()` to `$starterKit` for consistency and defense-in-depth.

Affected locations:
- `composer create-project` command (line ~500)
- `npx tiged` command (line ~511)
- Related `str_replace` patterns for livewire and workos variants

The `--github` and `--organization` flags are intentionally not changed in this PR as they involve more complex flag-passing behavior.

## Test plan

- [x] Verify `laravel new app --using=laravel/breeze` still works (package name)
- [x] Verify `laravel new app --using=https://github.com/user/repo` still works (URL)
- [x] `escapeshellarg()` wraps in single quotes which is valid for both patterns
- [x] Confirm `$directory` was already quoted in the same lines (showing intent)