### PR TITLE
Remove unsupported formatting tags from confirm prompt

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -562,7 +562,7 @@ class NewCommand extends Command
 
             if (! $runPackageManager && $input->isInteractive()) {
                 $runPackageManager = confirm(
-                    label: 'Would you like to run <options=bold>'.$packageManager->installCommand().'</> and <options=bold>'.$packageManager->buildCommand().'</>?'
+                    label: 'Would you like to run '.$packageManager->installCommand().' and '.$packageManager->buildCommand().'?'
                 );
             }
 


### PR DESCRIPTION
## Summary

Fixes #441. Removes formatting tags that are not supported by the confirm prompt, which were being displayed as raw text.

## Test plan

- [ ] Run installer and verify confirm prompts display cleanly without raw tags