### PR TITLE
Prevent infinite loop when installer self-update fails

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -315,7 +315,26 @@ class NewCommand extends Command
 
         if (confirm(label: 'Would you like to update now?')) {
             $this->runCommands(['composer global update laravel/installer'], $input, $output);
-            $this->proxyLaravelNew($input, $output);
+
+            // Check the installed version after update to avoid a re-proxy loop
+            // if the update didn't actually install a newer version...
+            $checkProcess = new Process(['composer', 'global', 'show', 'laravel/installer', '--format=json']);
+            $checkProcess->run();
+
+            if ($checkProcess->isSuccessful()) {
+                $installedData = json_decode($checkProcess->getOutput(), true);
+                $installedVersion = ltrim($installedData['versions'][0] ?? $version, 'v');
+
+                if (version_compare($installedVersion, $version) > 0) {
+                    $this->proxyLaravelNew($input, $output);
+
+                    return;
+                }
+            }
+
+            $output->writeln('');
+            $output->writeln('  <bg=yellow;fg=black> WARN </> Unable to update the installer. Continuing with the current version...');
+            $output->writeln('');
         }
     }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -316,9 +316,10 @@ class NewCommand extends Command
         if (confirm(label: 'Would you like to update now?')) {
             $this->runCommands(['composer global update laravel/installer'], $input, $output);
 
-            // Check the installed version after update to avoid a re-proxy loop
-            // if the update didn't actually install a newer version...
-            $checkProcess = new Process(['composer', 'global', 'show', 'laravel/installer', '--format=json']);
+            // Verify the update actually installed a newer version to avoid
+            // a re-proxy loop when the update silently fails or the version
+            // doesn't change (e.g. Herd's bundled phar, constraint conflicts)...
+            $checkProcess = Process::fromShellCommandline('composer global show laravel/installer --format=json');
             $checkProcess->run();
 
             if ($checkProcess->isSuccessful()) {
@@ -327,13 +328,11 @@ class NewCommand extends Command
 
                 if (version_compare($installedVersion, $version) > 0) {
                     $this->proxyLaravelNew($input, $output);
-
-                    return;
                 }
             }
 
             $output->writeln('');
-            $output->writeln('  <bg=yellow;fg=black> WARN </> Unable to update the installer. Continuing with the current version...');
+            $output->writeln('  <bg=yellow;fg=black> WARN </> The installer could not be updated. You may need to update manually. Continuing with the current version...');
             $output->writeln('');
         }
     }


### PR DESCRIPTION
## Summary

Fixes #471. When `composer global update laravel/installer` runs but doesn't actually install a newer version (constraint conflicts, Herd's bundled phar, network issues), the installer unconditionally re-proxies via `proxyLaravelNew`, which detects the same old version and loops forever.

This adds a post-update version check: after running the update, verify the installed version actually increased before re-proxying. If it didn't, warn the user and continue with the current version.

## Changes

- After `composer global update`, run `composer global show laravel/installer --format=json` to get the installed version
- Only call `proxyLaravelNew` if `version_compare` confirms the version increased
- Use `Process::fromShellCommandline` instead of `new Process([...])` for shell resolution (matches how `runCommands()` executes composer elsewhere, handles `.bat` files on Windows)
- Improved fallback message to be more actionable
- Removed dead `return` after `proxyLaravelNew` (it calls `exit` internally)

## Edge case handling

| Scenario | Result |
|----------|--------|
| Update succeeds, version increased | Re-proxies to new version (existing behaviour) |
| Update runs but version unchanged | Warns and continues with current version |
| `composer global show` fails | Falls through to warn (graceful degradation) |
| JSON output malformed or missing keys | `?? $version` fallback, version_compare returns 0, no re-proxy |

## Test plan

- [x] Verified `composer global show laravel/installer --format=json` returns valid JSON with `versions[0]` on Windows
- [x] Verified `ltrim('v5.25.2', 'v')` correctly strips the `v` prefix for version_compare
- [x] Tested all edge cases (empty output, malformed JSON, missing keys) degrade gracefully
- [x] All existing tests pass (5 tests, 7 assertions)
- [ ] Manual test: simulate a failed update and verify loop is broken