### PR TITLE
Fix Herd detection on Windows during update check

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -291,8 +291,8 @@ class NewCommand extends Command
         $output->writeln('');
         $output->writeln("  <bg=yellow;fg=black> WARN </> A new version of the Laravel installer is available. You have version {$version} installed, the latest version is {$latestVersion}.");
 
-        $laravelInstallerPath = (new ExecutableFinder())->find('laravel') ?? '';
-        $isHerd = str_contains($laravelInstallerPath, DIRECTORY_SEPARATOR.'Herd'.DIRECTORY_SEPARATOR);
+        $laravelInstallerPath = strtolower((new ExecutableFinder())->find('laravel') ?? '');
+        $isHerd = str_contains($laravelInstallerPath, DIRECTORY_SEPARATOR.'herd'.DIRECTORY_SEPARATOR);
         // Intalled via php.new
         $isHerdLite = str_contains($laravelInstallerPath, DIRECTORY_SEPARATOR.'herd-lite'.DIRECTORY_SEPARATOR);
 


### PR DESCRIPTION
## Summary

- The `ExecutableFinder` returns a path like `C:\Users\...\herd\bin\laravel.BAT` on Windows, but the detection checked for `\Herd\` (capital H)
- Since `str_contains` is case-sensitive, the Herd code path was skipped, falling through to `composer global update` which updates a different binary than the bundled phar
- This created an infinite update prompt loop on every `laravel new` invocation
- Fix: normalise the path to lowercase before checking

Fixes beyondcode/herd-community#1677

## Test plan

- [x] Verified `ExecutableFinder` returns lowercase `\herd\` path on Windows
- [x] Confirmed old logic returns `false`, new logic returns `true` for Herd detection
- [x] All existing tests pass (5 tests, 7 assertions)
- [ ] Manual test: run `laravel new` via Herd on Windows and confirm update prompt shows "Update via Herd Settings" instead of running `composer global update`