### PR TITLE
Filter non-string env values in Windows interactive process runner

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -1366,7 +1366,7 @@ class NewCommand extends Command
             2 => STDERR,
         ];
 
-        $envPairs = $env !== [] ? array_filter(array_merge($_SERVER, $_ENV, $env), 'is_string') : null;
+        $envPairs = $env !== [] ? array_filter(array_merge($_SERVER, $_ENV, $env), fn ($v) => ! is_array($v)) : null;
 
         $proc = proc_open($commandline, $descriptors, $pipes, $workingPath, $envPairs);
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -1366,7 +1366,7 @@ class NewCommand extends Command
             2 => STDERR,
         ];
 
-        $envPairs = $env !== [] ? array_merge($_SERVER, $_ENV, $env) : null;
+        $envPairs = $env !== [] ? array_filter(array_merge($_SERVER, $_ENV, $env), 'is_string') : null;
 
         $proc = proc_open($commandline, $descriptors, $pipes, $workingPath, $envPairs);
 


### PR DESCRIPTION
## Summary

- `$_SERVER['argv']` is an array that gets merged into the env pairs passed to `proc_open()` in `runCommandsInteractivelyOnWindows()`
- This triggers an "Array to string conversion" warning on both PHP 8.4 and 8.5
- Fix: filter arrays from the merged environment before passing to `proc_open`, matching Symfony Process's internal handling on the non-Windows code path
- Uses `! is_array()` rather than `is_string` to preserve integer env values like `GIT_TERMINAL_PROMPT => 0`

Fixes #494

> **Note:** The original issue reporter referenced PHP 8.5.4, which has not been officially released by php.net. However, Herd ships a pre-release PHP 8.5 build, and the warning is reproducible on both PHP 8.4.19 and Herd's bundled PHP 8.5.4.

## Proof

Tested on both available PHP versions:

```
PHP 8.4.19
----------------------------------------
WARNING TRIGGERED: Array to string conversion
WITH FIX: CLEAN

PHP 8.5.4
----------------------------------------
WARNING TRIGGERED: Array to string conversion
WITH FIX: CLEAN
```

Only arrays trigger the warning (integers like `GIT_TERMINAL_PROMPT => 0` do not):

```
Integer env value: CLEAN   (both PHP 8.4 and 8.5)
Array env value:   WARNING (both PHP 8.4 and 8.5)
```

## Test plan

- [x] Verified `$_SERVER['argv']` is the only array value in the merged env
- [x] Confirmed warning triggers on PHP 8.4.19
- [x] Confirmed warning triggers on PHP 8.5.4 (Herd pre-release build)
- [x] Confirmed fix resolves warning on both versions
- [x] Confirmed integer env values (e.g. `GIT_TERMINAL_PROMPT => 0`) are preserved
- [x] All existing tests pass (5 tests, 7 assertions)
- [x] Non-Windows code path unaffected (uses Symfony Process which filters internally)