### PR TITLE
[5.x] Ensure update doesnt loop in Windows 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 phpunit.xml
 .phpunit.result.cache
+/.idea

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -325,7 +325,7 @@ class NewCommand extends Command
         }
 
         if (confirm(label: 'Would you like to update now?')) {
-            $this->runCommands(['composer global update laravel/installer'], $input, $output);
+            $this->runCommands(['composer global update laravel/installer --with-all-dependencies'], $input, $output);
             $this->proxyLaravelNew($input, $output);
         }
     }


### PR DESCRIPTION

Initially, I was having it loop constantly:

<details>

<summary> Video </summary>

https://github.com/user-attachments/assets/318ad595-c4bf-4957-9b1a-6205b3ca895f

</details>

This is because the dependencies were outdated, but it never actually told me. 

This PR adds `--with-all-dependencies` when updating the installer getting fresh dependencies alongside it feels like the right behaviour All the composer versions are set anyway, so I think it's safe enough? 

I've also ignored the .idea dir, while here :) 

This means I then get proper updating output:

<details>

<summary> Image</summary>

<img width="1270" height="1286" alt="image" src="https://github.com/user-attachments/assets/bc7a4ffd-582c-4f90-906d-4e7a98d00d00" />

</details> 

There's probably some edge cases for it to loop still, but thought this was a nice step.


The alternative, if you dont like this is `composer global require laravel/installer:{$latestVersion}` if you want the end user to see the outdated stuff.