### PR TITLE
Fix install command with database and starterkit options specified

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, fileinfo
+          extensions: dom, curl, libxml, mbstring, zip, fileinfo, pdo, pdo_mysql, pdo_pgsql, pdo_sqlite
           tools: composer:v2
           coverage: none
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -874,11 +874,13 @@ class NewCommand extends Command
             $databaseOptions = $this->databaseOptions()
         )->keys()->first();
 
-        if (! $input->getOption('database') && $this->usingStarterKit($input)) {
+        if ($this->usingStarterKit($input)) {
             // Starter kits will already be migrated in post composer create-project command...
             $migrate = false;
 
-            $input->setOption('database', 'sqlite');
+            if (! $input->getOption('database')) {
+                $input->setOption('database', 'sqlite');
+            }
         }
 
         if (! $input->getOption('database') && $input->isInteractive()) {


### PR DESCRIPTION
## Summary

Ensures the `--database` option is respected when using starter kits (React, Vue, Svelte), preventing it from being overridden.

## Changes

The selected database (e.g. `pgsql`) was correctly set during project creation, but later overwritten by the starter kit scaffolding which defaults to SQLite.

This change ensures that:
- The `--database` option takes precedence
- Starter kits do not override an explicitly selected database
- The final `.env` reflects the user’s chosen database

## Test plan

- [ ] Verify `laravel new app --database=pgsql` sets `DB_CONNECTION=pgsql`
- [ ] Verify `laravel new app --database=pgsql --react` keeps `DB_CONNECTION=pgsql`
- [ ] Verify `laravel new app --database=pgsql --vue` keeps `DB_CONNECTION=pgsql`
- [ ] Verify `laravel new app --database=pgsql --svelte` keeps `DB_CONNECTION=pgsql`
- [ ] Verify `laravel new app --react` defaults to SQLite
- [ ] Verify other databases (e.g. `mysql`) are respected with starter kits