### PR TITLE
Allow Symfony 8 in composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
         "illuminate/filesystem": "^10.20|^11.0|^12.0|^13.0",
         "illuminate/support": "^10.20|^11.0|^12.0|^13.0",
         "laravel/prompts": "^0.1.18|^0.2.0|^0.3.0",
-        "symfony/console": "^6.2|^7.0",
-        "symfony/process": "^6.2|^7.0",
-        "symfony/polyfill-mbstring": "^1.31"
+        "symfony/console": "^6.2|^7.0|^8.0",
+        "symfony/polyfill-mbstring": "^1.31",
+        "symfony/process": "^6.2|^7.0|^8.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1",

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Support\ProcessUtils;
 use Illuminate\Support\Str;
 use Laravel\Installer\Console\Enums\NodePackageManager;
 use Laravel\Prompts\Support\Logger;
+use Override;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RuntimeException;
@@ -47,7 +48,8 @@ class NewCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    #[Override]
+    protected function configure(): void
     {
         $this
             ->setName('new')
@@ -84,7 +86,8 @@ class NewCommand extends Command
      *
      * @return void
      */
-    protected function interact(InputInterface $input, OutputInterface $output)
+    #[Override]
+    protected function interact(InputInterface $input, OutputInterface $output): void
     {
         parent::interact($input, $output);
 

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -26,7 +26,11 @@ class NewCommandTest extends TestCase
         }
 
         $app = new Application('Laravel Installer');
-        $app->add(new NewCommand);
+        if (method_exists($app, 'addCommand')) {
+            $app->addCommand(new NewCommand);
+        } else {
+            $app->add(new NewCommand);
+        }
 
         $tester = new CommandTester($app->find('new'));
 
@@ -55,7 +59,11 @@ class NewCommandTest extends TestCase
         }
 
         $app = new Application('Laravel Installer');
-        $app->add(new NewCommand);
+        if (method_exists($app, 'addCommand')) {
+            $app->addCommand(new NewCommand);
+        } else {
+            $app->add(new NewCommand);
+        }
 
         $tester = new CommandTester($app->find('new'));
 

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -25,12 +25,7 @@ class NewCommandTest extends TestCase
             }
         }
 
-        $app = new Application('Laravel Installer');
-        if (method_exists($app, 'addCommand')) {
-            $app->addCommand(new NewCommand);
-        } else {
-            $app->add(new NewCommand);
-        }
+        $app = $this->createApplication();
 
         $tester = new CommandTester($app->find('new'));
 
@@ -58,12 +53,7 @@ class NewCommandTest extends TestCase
             }
         }
 
-        $app = new Application('Laravel Installer');
-        if (method_exists($app, 'addCommand')) {
-            $app->addCommand(new NewCommand);
-        } else {
-            $app->add(new NewCommand);
-        }
+        $app = $this->createApplication();
 
         $tester = new CommandTester($app->find('new'));
 
@@ -115,5 +105,21 @@ class NewCommandTest extends TestCase
         $this->assertSame(getcwd().'/'.$relativePath, $command->getInstallationDirectoryPublic($relativePath));
 
         $this->assertSame('.', $command->getInstallationDirectoryPublic('.'));
+    }
+
+    /**
+     * @return \Symfony\Component\Console\Application
+     */
+    private function createApplication(): Application
+    {
+        $app = new Application('Laravel Installer');
+
+        if (method_exists($app, 'addCommand')) {
+            $app->addCommand(new NewCommand);
+        } else {
+            $app->add(new NewCommand);
+        }
+
+        return $app;
     }
 }


### PR DESCRIPTION
Update `composer.json` to include `^8.0` in the version constraints for:

- `symfony/console`
- `symfony/process`

Adds `void` return types to `configure()` and `interact()`, plus an `#[Override]` attribute to enforce parent method compatibility at compile time in:

- `src/NewCommand.php`
