### PR TITLE
Fix laravel/prompts version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^8.2",
         "illuminate/filesystem": "^10.20|^11.0|^12.0|^13.0",
         "illuminate/support": "^10.20|^11.0|^12.0|^13.0",
-        "laravel/prompts": "^0.1.18|^0.2.0|^0.3.0",
+        "laravel/prompts": "^0.1.18|^0.2.0|^0.3.17",
         "symfony/console": "^6.2|^7.0",
         "symfony/process": "^6.2|^7.0",
         "symfony/polyfill-mbstring": "^1.31"

--- a/src/Concerns/ConfiguresPrompts.php
+++ b/src/Concerns/ConfiguresPrompts.php
@@ -8,6 +8,7 @@ use Laravel\Prompts\PasswordPrompt;
 use Laravel\Prompts\Prompt;
 use Laravel\Prompts\SelectPrompt;
 use Laravel\Prompts\SuggestPrompt;
+use Laravel\Prompts\Task as TaskPrompt;
 use Laravel\Prompts\TextPrompt;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -94,6 +95,10 @@ trait ConfiguresPrompts
             $prompt->validate,
             $output
         ));
+
+        TaskPrompt::fallbackUsing(function (TaskPrompt $prompt) {
+            //
+        });
     }
 
     /**


### PR DESCRIPTION
`keepSummary` was introduced in https://github.com/laravel/prompts/releases/tag/v0.3.17

Introduced via https://github.com/laravel/installer/pull/503

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
