### PR TITLE
Skip task prompt on Windows

### DIFF
--- a/src/Concerns/ConfiguresPrompts.php
+++ b/src/Concerns/ConfiguresPrompts.php
@@ -8,7 +8,6 @@ use Laravel\Prompts\PasswordPrompt;
 use Laravel\Prompts\Prompt;
 use Laravel\Prompts\SelectPrompt;
 use Laravel\Prompts\SuggestPrompt;
-use Laravel\Prompts\Task as TaskPrompt;
 use Laravel\Prompts\TextPrompt;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -95,10 +94,6 @@ trait ConfiguresPrompts
             $prompt->validate,
             $output
         ));
-
-        TaskPrompt::fallbackUsing(function (TaskPrompt $prompt) {
-            //
-        });
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -1346,7 +1346,7 @@ class NewCommand extends Command
             );
         }
 
-        if (function_exists('Laravel\Prompts\task') && ! array_is_list($commands) && $this->useConciseOutput($output)) {
+        if (function_exists('Laravel\Prompts\task') && function_exists('pcntl_fork') && ! array_is_list($commands) && $this->useConciseOutput($output)) {
             return $this->runCommandsAsTask($commands, $workingPath, $env, $taskLabel);
         }
 


### PR DESCRIPTION
The concise task output relies on `pcntl_fork`, which isn't available on Windows. Check for it before using the task prompt and fall back to the standard command output. Also drops the empty TaskPrompt fallback since it's no longer needed.
