### PR TITLE
Emit structured JSON output when invoked by AI agents

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "illuminate/filesystem": "^10.20|^11.0|^12.0|^13.0",
         "illuminate/support": "^10.20|^11.0|^12.0|^13.0",
         "laravel/prompts": "^0.1.18|^0.2.0|^0.3.17",
+        "shipfastlabs/agent-detector": "^1.1.3",
         "symfony/console": "^6.2|^7.0|^8.0",
         "symfony/polyfill-mbstring": "^1.31",
         "symfony/process": "^6.2|^7.0|^8.0"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "illuminate/filesystem": "^10.20|^11.0|^12.0|^13.0",
         "illuminate/support": "^10.20|^11.0|^12.0|^13.0",
         "laravel/prompts": "^0.1.18|^0.2.0|^0.3.17",
-        "shipfastlabs/agent-detector": "^1.1.3",
+        "laravel/agent-detector": "^2.0.0",
         "symfony/console": "^6.2|^7.0|^8.0",
         "symfony/polyfill-mbstring": "^1.31",
         "symfony/process": "^6.2|^7.0|^8.0"

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -174,7 +174,7 @@ class Agent
             $payload[$key] = $value;
         }
 
-        fwrite(STDOUT, json_encode($payload, JSON_UNESCAPED_SLASHES) . PHP_EOL);
+        fwrite(STDOUT, json_encode($payload, JSON_UNESCAPED_SLASHES).PHP_EOL);
     }
 
     /**

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -62,10 +62,10 @@ class Agent
     /**
      * Capture the resolved installation details for the JSON output.
      */
-    public function rememberInstallation(string $name, string $directory): void
+    public function rememberInstallation(string $directory): void
     {
-        $this->name = $name;
         $this->directory = $directory;
+        $this->name = basename($directory === '.' ? (string) getcwd() : $directory);
     }
 
     /**

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Laravel\Installer\Console;
+
+use AgentDetector\AgentDetector;
+use AgentDetector\AgentResult;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\StreamOutput;
+
+class Agent
+{
+    protected ?AgentResult $result;
+
+    /**
+     * The resolved installation name, captured for the JSON output.
+     */
+    protected ?string $name = null;
+
+    /**
+     * The resolved installation directory, captured for the JSON output.
+     */
+    protected ?string $directory = null;
+
+    /**
+     * Path to the subprocess log file, when one is open.
+     */
+    protected ?string $logPath = null;
+
+    /**
+     * Open file handle for the subprocess log, when one is open.
+     *
+     * @var resource|null
+     */
+    protected $logHandle = null;
+
+    public function __construct()
+    {
+        $this->result = AgentDetector::detect();
+    }
+
+    /**
+     * Determine whether the command is running under a detected agent.
+     */
+    public function isActive(): bool
+    {
+        return $this->result?->isAgent ?? false;
+    }
+
+    /**
+     * The detected agent name, if any.
+     */
+    public function name(): ?string
+    {
+        return $this->result?->name;
+    }
+
+    /**
+     * Capture the resolved installation details for the JSON output.
+     */
+    public function rememberInstallation(string $name, string $directory): void
+    {
+        $this->name = $name;
+        $this->directory = $directory;
+    }
+
+    /**
+     * Open a log destination to capture subprocess output during agent runs.
+     *
+     * Prefer a tempfile so the failure payload can include a stable path for
+     * the agent to re-read in full. Falls back to an in-memory buffer; the
+     * tail is still surfaced in the JSON payload, just without a `log` path.
+     */
+    public function openLog(): StreamOutput
+    {
+        [$path, $handle] = $this->resolveLogPathAndHandle();
+
+        $this->logPath = $path;
+        $this->logHandle = $handle;
+
+        return new StreamOutput($handle, OutputInterface::VERBOSITY_NORMAL, false);
+    }
+
+    /**
+     * Close and remove the agent log file (used on the success path).
+     */
+    public function discardLog(): void
+    {
+        if (is_resource($this->logHandle)) {
+            @fclose($this->logHandle);
+            $this->logHandle = null;
+        }
+
+        if ($this->logPath !== null) {
+            @unlink($this->logPath);
+            $this->logPath = null;
+        }
+    }
+
+    /**
+     * Emit a successful agent result with optional extra payload.
+     */
+    public function emitSuccess(array $extra = []): void
+    {
+        $this->emit(true, $extra);
+    }
+
+    /**
+     * Emit a failed agent result with optional extra payload, merged with log details.
+     */
+    public function emitFailure(array $extra = []): void
+    {
+        $this->emit(false, $extra + $this->failureDetails());
+    }
+
+    /**
+     * Read the last N lines of the agent log, with ANSI escapes stripped.
+     */
+    public function readLogTail(string $path, int $lines = 50): string
+    {
+        $content = @file_get_contents($path);
+
+        if ($content === false) {
+            return '';
+        }
+
+        return $this->formatTail($content, $lines);
+    }
+
+    /**
+     * Build the log + tail fields for the agent failure payload.
+     */
+    protected function failureDetails(): array
+    {
+        if (! is_resource($this->logHandle)) {
+            return [];
+        }
+
+        @fflush($this->logHandle);
+
+        $details = [];
+
+        if ($this->logPath !== null && file_exists($this->logPath)) {
+            $details['log'] = $this->logPath;
+            $details['tail'] = $this->readLogTail($this->logPath);
+        } else {
+            @rewind($this->logHandle);
+            $content = stream_get_contents($this->logHandle);
+            $details['tail'] = $this->formatTail($content === false ? '' : $content);
+        }
+
+        @fclose($this->logHandle);
+        $this->logHandle = null;
+
+        return $details;
+    }
+
+    /**
+     * Write the minimal JSON result for agent invocations.
+     */
+    protected function emit(bool $success, array $extra = []): void
+    {
+        $payload = ['success' => $success];
+
+        if ($this->name !== null) {
+            $payload['name'] = $this->name;
+        }
+
+        if ($this->directory !== null) {
+            $payload['directory'] = $this->directory;
+        }
+
+        foreach ($extra as $key => $value) {
+            $payload[$key] = $value;
+        }
+
+        fwrite(STDOUT, json_encode($payload, JSON_UNESCAPED_SLASHES).PHP_EOL);
+    }
+
+    /**
+     * Attempt to open a temporary file for logging, falling back to an in-memory stream on failure.
+     *
+     * @return array{string|null, resource}
+     */
+    protected function resolveLogPathAndHandle(): array
+    {
+        $path = tempnam(sys_get_temp_dir(), 'laravel-installer-');
+        $handle = $path !== false ? @fopen($path, 'w+') : false;
+
+        if ($handle !== false) {
+            return [$path, $handle];
+        }
+
+        if ($path !== false) {
+            @unlink($path);
+        }
+
+        $handle = fopen('php://temp', 'w+');
+
+        return [$path, $handle];
+    }
+
+    /**
+     * Strip ANSI escapes and return the last N lines of the given content.
+     */
+    protected function formatTail(string $content, int $lines = 50): string
+    {
+        if ($content === '') {
+            return '';
+        }
+
+        $stripped = preg_replace('/\x1b\[[0-9;?]*[a-zA-Z]/', '', $content);
+        $allLines = preg_split("/\r\n|\n|\r/", rtrim($stripped ?? $content));
+
+        return implode("\n", array_slice($allLines, -$lines));
+    }
+}

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -34,7 +34,7 @@ class Agent
     protected $logHandle = null;
 
     /**
-     * Whether or not the command succeeded
+     * Whether or not the command succeeded.
      */
     protected bool $succeeded = false;
 

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -103,6 +103,20 @@ class Agent
     }
 
     /**
+     * Read the last N lines of the agent log, with ANSI escapes stripped.
+     */
+    public function readLogTail(string $path, int $lines = 50): string
+    {
+        $content = @file_get_contents($path);
+
+        if ($content === false) {
+            return '';
+        }
+
+        return $this->formatTail($content, $lines);
+    }
+
+    /**
      * Close and remove the agent log file (used on the success path).
      */
     protected function discardLog(): void
@@ -189,20 +203,6 @@ class Agent
         $handle = fopen('php://temp', 'w+');
 
         return [$path, $handle];
-    }
-
-    /**
-     * Read the last N lines of the agent log, with ANSI escapes stripped.
-     */
-    protected function readLogTail(string $path, int $lines = 50): string
-    {
-        $content = @file_get_contents($path);
-
-        if ($content === false) {
-            return '';
-        }
-
-        return $this->formatTail($content, $lines);
     }
 
     /**

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\Installer\Console;
 
-use AgentDetector\AgentDetector;
-use AgentDetector\AgentResult;
+use Laravel\AgentDetector\AgentDetector;
+use Laravel\AgentDetector\AgentResult;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -33,6 +33,11 @@ class Agent
      */
     protected $logHandle = null;
 
+    /**
+     * Whether or not the command succeeded
+     */
+    protected bool $succeeded = false;
+
     public function __construct()
     {
         $this->result = AgentDetector::detect();
@@ -51,7 +56,7 @@ class Agent
      */
     public function name(): ?string
     {
-        return $this->result?->name;
+        return $this->result?->knownAgent()?->label();
     }
 
     /**
@@ -81,22 +86,6 @@ class Agent
     }
 
     /**
-     * Close and remove the agent log file (used on the success path).
-     */
-    public function discardLog(): void
-    {
-        if (is_resource($this->logHandle)) {
-            @fclose($this->logHandle);
-            $this->logHandle = null;
-        }
-
-        if ($this->logPath !== null) {
-            @unlink($this->logPath);
-            $this->logPath = null;
-        }
-    }
-
-    /**
      * Emit a successful agent result with optional extra payload.
      */
     public function emitSuccess(array $extra = []): void
@@ -114,17 +103,19 @@ class Agent
     }
 
     /**
-     * Read the last N lines of the agent log, with ANSI escapes stripped.
+     * Close and remove the agent log file (used on the success path).
      */
-    public function readLogTail(string $path, int $lines = 50): string
+    protected function discardLog(): void
     {
-        $content = @file_get_contents($path);
-
-        if ($content === false) {
-            return '';
+        if (is_resource($this->logHandle)) {
+            @fclose($this->logHandle);
+            $this->logHandle = null;
         }
 
-        return $this->formatTail($content, $lines);
+        if ($this->logPath !== null) {
+            @unlink($this->logPath);
+            $this->logPath = null;
+        }
     }
 
     /**
@@ -198,6 +189,20 @@ class Agent
         $handle = fopen('php://temp', 'w+');
 
         return [$path, $handle];
+    }
+
+    /**
+     * Read the last N lines of the agent log, with ANSI escapes stripped.
+     */
+    protected function readLogTail(string $path, int $lines = 50): string
+    {
+        $content = @file_get_contents($path);
+
+        if ($content === false) {
+            return '';
+        }
+
+        return $this->formatTail($content, $lines);
     }
 
     /**

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -101,6 +101,7 @@ class Agent
      */
     public function emitSuccess(array $extra = []): void
     {
+        $this->discardLog();
         $this->emit(true, $extra);
     }
 
@@ -173,7 +174,7 @@ class Agent
             $payload[$key] = $value;
         }
 
-        fwrite(STDOUT, json_encode($payload, JSON_UNESCAPED_SLASHES).PHP_EOL);
+        fwrite(STDOUT, json_encode($payload, JSON_UNESCAPED_SLASHES) . PHP_EOL);
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -73,7 +73,6 @@ class NewCommand extends Command
         }
 
         if ($exitCode === 0) {
-            $this->agent->discardLog();
             $this->agent->emitSuccess();
         } else {
             $this->agent->emitFailure();

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -2,8 +2,6 @@
 
 namespace Laravel\Installer\Console;
 
-use AgentDetector\AgentDetector;
-use AgentDetector\AgentResult;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Composer;
 use Illuminate\Support\ProcessUtils;
@@ -19,7 +17,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
@@ -47,31 +44,9 @@ class NewCommand extends Command
     protected $composer;
 
     /**
-     * The detected agent, if any.
+     * The agent context, encapsulating detection and JSON output behavior.
      */
-    protected ?AgentResult $agentResult = null;
-
-    /**
-     * The resolved installation name, captured for agent JSON output.
-     */
-    protected ?string $resolvedName = null;
-
-    /**
-     * The resolved installation directory, captured for agent JSON output.
-     */
-    protected ?string $resolvedDirectory = null;
-
-    /**
-     * Path to the agent-mode subprocess log file, when one is open.
-     */
-    protected ?string $agentLogPath = null;
-
-    /**
-     * Open file handle for the agent-mode log, when one is open.
-     *
-     * @var resource|null
-     */
-    protected $agentLogHandle = null;
+    protected Agent $agent;
 
     /**
      * Detect agents, suppress interactive output, and emit a JSON result.
@@ -79,191 +54,32 @@ class NewCommand extends Command
     #[Override]
     public function run(InputInterface $input, OutputInterface $output): int
     {
-        $this->agentResult = AgentDetector::detect();
+        $this->agent = new Agent;
 
-        if (! $this->isAgent()) {
+        if (! $this->agent->isActive()) {
             return parent::run($input, $output);
         }
 
         $input->setInteractive(false);
 
-        $logOutput = $this->openAgentLog();
+        $logOutput = $this->agent->openLog();
 
         try {
             $exitCode = parent::run($input, $logOutput);
         } catch (Throwable $e) {
-            $this->emitAgentFailure(['error' => $e->getMessage()] + $this->failureDetails());
+            $this->agent->emitFailure(['error' => $e->getMessage()]);
 
             return 1;
         }
 
         if ($exitCode === 0) {
-            $this->discardAgentLog();
-            $this->emitAgentSuccess();
+            $this->agent->discardLog();
+            $this->agent->emitSuccess();
         } else {
-            $this->emitAgentFailure($this->failureDetails());
+            $this->agent->emitFailure();
         }
 
         return $exitCode;
-    }
-
-    /**
-     * Open a log destination to capture subprocess output during agent runs.
-     *
-     * Prefer a tempfile so the failure payload can include a stable path for
-     * the agent to re-read in full. Falls back to an in-memory buffer; the
-     * tail is still surfaced in the JSON payload, just without a `log` path.
-     */
-    protected function openAgentLog(): StreamOutput
-    {
-        [$path, $handle] = $this->resolveAgentLogPathAndHandle();
-
-        $this->agentLogPath = $path;
-        $this->agentLogHandle = $handle;
-
-        return new StreamOutput($handle, OutputInterface::VERBOSITY_NORMAL, false);
-    }
-
-    /**
-     * Attempt to open a temporary file for logging, falling back to an in-memory stream on failure.
-     *
-     * @return array{string|null, resource}
-     */
-    protected function resolveAgentLogPathAndHandle(): array
-    {
-        $path = tempnam(sys_get_temp_dir(), 'laravel-installer-');
-        $handle = $path !== false ? @fopen($path, 'w+') : false;
-
-        if ($handle !== false) {
-            return [$path, $handle];
-        }
-
-        if ($path !== false) {
-            @unlink($path);
-        }
-
-        $handle = fopen('php://temp', 'w+');
-
-        return [$path, $handle];
-    }
-
-    /**
-     * Close and remove the agent log file (used on the success path).
-     */
-    protected function discardAgentLog(): void
-    {
-        if (is_resource($this->agentLogHandle)) {
-            @fclose($this->agentLogHandle);
-            $this->agentLogHandle = null;
-        }
-
-        if ($this->agentLogPath !== null) {
-            @unlink($this->agentLogPath);
-            $this->agentLogPath = null;
-        }
-    }
-
-    /**
-     * Build the log + tail fields for the agent failure payload.
-     */
-    protected function failureDetails(): array
-    {
-        if (! is_resource($this->agentLogHandle)) {
-            return [];
-        }
-
-        @fflush($this->agentLogHandle);
-
-        $details = [];
-
-        if ($this->agentLogPath !== null && file_exists($this->agentLogPath)) {
-            $details['log'] = $this->agentLogPath;
-            $details['tail'] = $this->readLogTail($this->agentLogPath);
-        } else {
-            @rewind($this->agentLogHandle);
-            $content = stream_get_contents($this->agentLogHandle);
-            $details['tail'] = $this->formatTail($content === false ? '' : $content);
-        }
-
-        @fclose($this->agentLogHandle);
-        $this->agentLogHandle = null;
-
-        return $details;
-    }
-
-    /**
-     * Determine whether this command is running under a detected agent.
-     */
-    protected function isAgent(): bool
-    {
-        return $this->agentResult?->isAgent ?? false;
-    }
-
-    /**
-     * Emit a successful agent result with optional extra payload.
-     */
-    protected function emitAgentSuccess(array $extra = []): void
-    {
-        $this->emitAgentResult(true, $extra);
-    }
-
-    /**
-     * Emit a failed agent result with optional extra payload, merged with log details.
-     */
-    protected function emitAgentFailure(array $extra = []): void
-    {
-        $this->emitAgentResult(false, $extra + $this->failureDetails());
-    }
-
-    /**
-     * Write the minimal JSON result for agent invocations.
-     */
-    protected function emitAgentResult(bool $success, array $extra = []): void
-    {
-        $payload = ['success' => $success];
-
-        if ($this->resolvedName !== null) {
-            $payload['name'] = $this->resolvedName;
-        }
-
-        if ($this->resolvedDirectory !== null) {
-            $payload['directory'] = $this->resolvedDirectory;
-        }
-
-        foreach ($extra as $key => $value) {
-            $payload[$key] = $value;
-        }
-
-        fwrite(STDOUT, json_encode($payload, JSON_UNESCAPED_SLASHES).PHP_EOL);
-    }
-
-    /**
-     * Read the last N lines of the agent log, with ANSI escapes stripped.
-     */
-    protected function readLogTail(string $path, int $lines = 50): string
-    {
-        $content = @file_get_contents($path);
-
-        if ($content === false) {
-            return '';
-        }
-
-        return $this->formatTail($content, $lines);
-    }
-
-    /**
-     * Strip ANSI escapes and return the last N lines of the given content.
-     */
-    protected function formatTail(string $content, int $lines = 50): string
-    {
-        if ($content === '') {
-            return '';
-        }
-
-        $stripped = preg_replace('/\x1b\[[0-9;?]*[a-zA-Z]/', '', $content);
-        $allLines = preg_split("/\r\n|\n|\r/", rtrim($stripped ?? $content));
-
-        return implode("\n", array_slice($allLines, -$lines));
     }
 
     /**
@@ -312,13 +128,13 @@ class NewCommand extends Command
 
         $this->configurePrompts($input, $output);
 
-        if (! $this->isAgent()) {
+        if (! $this->agent->isActive()) {
             $this->displayHeader($output);
         }
 
         $this->ensureExtensionsAreAvailable($input, $output);
 
-        if (! $this->isAgent()) {
+        if (! $this->agent->isActive()) {
             $this->checkForUpdate($input, $output);
         }
 
@@ -683,8 +499,7 @@ class NewCommand extends Command
 
         $directory = $this->getInstallationDirectory($name);
 
-        $this->resolvedName = $name;
-        $this->resolvedDirectory = $directory;
+        $this->agent->rememberInstallation($name, $directory);
 
         $this->composer = new Composer(new Filesystem, $directory);
 
@@ -849,7 +664,7 @@ class NewCommand extends Command
                 $this->commitChanges('Configure Boost post-update script', $directory, $input, $output);
             }
 
-            if (! $this->isAgent()) {
+            if (! $this->agent->isActive()) {
                 info("Application ready in <options=bold>[{$name}]</>. You can start your local development using:");
 
                 $output->writeln($this->finalStep("cd {$name}"));
@@ -891,8 +706,8 @@ class NewCommand extends Command
 
         $headers = ['User-Agent: Laravel Installer'];
 
-        if ($this->isAgent() && $this->agentResult->name !== null) {
-            $headers[] = 'X-Agent: '.$this->agentResult->name;
+        if ($this->agent->isActive() && $this->agent->name() !== null) {
+            $headers[] = 'X-Agent: '.$this->agent->name();
         }
 
         curl_setopt_array($curl, [
@@ -1585,7 +1400,7 @@ class NewCommand extends Command
 
         $process = Process::fromShellCommandline($commandline, $workingPath, $env, null, null);
 
-        if (Process::isTtySupported() && ! $this->isAgent()) {
+        if (Process::isTtySupported() && ! $this->agent->isActive()) {
             try {
                 $process->setTty(true);
             } catch (RuntimeException $e) {
@@ -1605,7 +1420,7 @@ class NewCommand extends Command
         return function_exists('Laravel\Prompts\task')
             && function_exists('pcntl_fork')
             && ! array_is_list($commands)
-            && ! $this->isAgent() && $this->useConciseOutput($output);
+            && ! $this->agent->isActive() && $this->useConciseOutput($output);
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -108,10 +108,11 @@ class NewCommand extends Command
     }
 
     /**
-     * Open a temporary log file to capture subprocess output during agent runs.
+     * Open a log destination to capture subprocess output during agent runs.
      *
-     * Falls back to a spillable in-memory buffer if a tempfile cannot be opened,
-     * so the install can still proceed even when no diagnostics will be surfaced.
+     * Prefer a tempfile so the failure payload can include a stable path for
+     * the agent to re-read in full. Falls back to an in-memory buffer; the
+     * tail is still surfaced in the JSON payload, just without a `log` path.
      */
     protected function openAgentLog(): StreamOutput
     {
@@ -123,7 +124,9 @@ class NewCommand extends Command
                 @unlink($path);
             }
 
-            return new StreamOutput(fopen('php://temp', 'w+'), OutputInterface::VERBOSITY_NORMAL, false);
+            $this->agentLogHandle = fopen('php://temp', 'w+');
+
+            return new StreamOutput($this->agentLogHandle, OutputInterface::VERBOSITY_NORMAL, false);
         }
 
         $this->agentLogPath = $path;
@@ -153,18 +156,27 @@ class NewCommand extends Command
      */
     protected function failureDetails(): array
     {
-        if ($this->agentLogPath === null || ! file_exists($this->agentLogPath)) {
+        if (! is_resource($this->agentLogHandle)) {
             return [];
         }
 
-        if (is_resource($this->agentLogHandle)) {
-            @fflush($this->agentLogHandle);
+        @fflush($this->agentLogHandle);
+
+        $details = [];
+
+        if ($this->agentLogPath !== null && file_exists($this->agentLogPath)) {
+            $details['log'] = $this->agentLogPath;
+            $details['tail'] = $this->readLogTail($this->agentLogPath);
+        } else {
+            @rewind($this->agentLogHandle);
+            $content = stream_get_contents($this->agentLogHandle);
+            $details['tail'] = $this->formatTail($content === false ? '' : $content);
         }
 
-        return [
-            'log' => $this->agentLogPath,
-            'tail' => $this->readLogTail($this->agentLogPath),
-        ];
+        @fclose($this->agentLogHandle);
+        $this->agentLogHandle = null;
+
+        return $details;
     }
 
     /**
@@ -204,7 +216,19 @@ class NewCommand extends Command
     {
         $content = @file_get_contents($path);
 
-        if ($content === false || $content === '') {
+        if ($content === false) {
+            return '';
+        }
+
+        return $this->formatTail($content, $lines);
+    }
+
+    /**
+     * Strip ANSI escapes and return the last N lines of the given content.
+     */
+    protected function formatTail(string $content, int $lines = 50): string
+    {
+        if ($content === '') {
             return '';
         }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -18,8 +18,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
@@ -75,15 +75,29 @@ class NewCommand extends Command
 
         $input->setInteractive(false);
 
+        $logPath = tempnam(sys_get_temp_dir(), 'laravel-installer-');
+        $logHandle = $logPath !== false ? @fopen($logPath, 'w+') : false;
+        $logOutput = $logHandle !== false
+            ? new StreamOutput($logHandle, OutputInterface::VERBOSITY_NORMAL, false)
+            : new StreamOutput(fopen('php://memory', 'w+'), OutputInterface::VERBOSITY_NORMAL, false);
+
         try {
-            $exitCode = parent::run($input, new NullOutput);
+            $exitCode = parent::run($input, $logOutput);
         } catch (Throwable $e) {
-            $this->emitAgentResult(false, ['error' => $e->getMessage()]);
+            $this->emitAgentResult(false, ['error' => $e->getMessage()] + $this->logDetails($logPath ?: null, $logHandle ?: null));
 
             return 1;
         }
 
-        $this->emitAgentResult($exitCode === 0);
+        if ($exitCode === 0) {
+            if ($logPath !== false) {
+                @unlink($logPath);
+            }
+
+            $this->emitAgentResult(true);
+        } else {
+            $this->emitAgentResult(false, $this->logDetails($logPath ?: null, $logHandle ?: null));
+        }
 
         return $exitCode;
     }
@@ -116,6 +130,44 @@ class NewCommand extends Command
         }
 
         fwrite(STDOUT, json_encode($payload, JSON_UNESCAPED_SLASHES).PHP_EOL);
+    }
+
+    /**
+     * Build the log + tail fields for the agent failure payload.
+     *
+     * @param  resource|null  $logHandle
+     */
+    protected function logDetails(?string $logPath, $logHandle = null): array
+    {
+        if ($logPath === null || ! file_exists($logPath)) {
+            return [];
+        }
+
+        if (is_resource($logHandle)) {
+            @fflush($logHandle);
+        }
+
+        return [
+            'log' => $logPath,
+            'tail' => $this->readLogTail($logPath),
+        ];
+    }
+
+    /**
+     * Read the last N lines of the agent log, with ANSI escapes stripped.
+     */
+    protected function readLogTail(string $path, int $lines = 50): string
+    {
+        $content = @file_get_contents($path);
+
+        if ($content === false || $content === '') {
+            return '';
+        }
+
+        $content = preg_replace('/\x1b\[[0-9;?]*[a-zA-Z]/', '', $content);
+        $allLines = preg_split("/\r\n|\n|\r/", rtrim($content));
+
+        return implode("\n", array_slice($allLines, -$lines));
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -62,6 +62,18 @@ class NewCommand extends Command
     protected ?string $resolvedDirectory = null;
 
     /**
+     * Path to the agent-mode subprocess log file, when one is open.
+     */
+    protected ?string $agentLogPath = null;
+
+    /**
+     * Open file handle for the agent-mode log, when one is open.
+     *
+     * @var resource|null
+     */
+    protected $agentLogHandle = null;
+
+    /**
      * Detect agents, suppress interactive output, and emit a JSON result.
      */
     #[Override]
@@ -75,31 +87,84 @@ class NewCommand extends Command
 
         $input->setInteractive(false);
 
-        $logPath = tempnam(sys_get_temp_dir(), 'laravel-installer-');
-        $logHandle = $logPath !== false ? @fopen($logPath, 'w+') : false;
-        $logOutput = $logHandle !== false
-            ? new StreamOutput($logHandle, OutputInterface::VERBOSITY_NORMAL, false)
-            : new StreamOutput(fopen('php://memory', 'w+'), OutputInterface::VERBOSITY_NORMAL, false);
+        $logOutput = $this->openAgentLog();
 
         try {
             $exitCode = parent::run($input, $logOutput);
         } catch (Throwable $e) {
-            $this->emitAgentResult(false, ['error' => $e->getMessage()] + $this->logDetails($logPath ?: null, $logHandle ?: null));
+            $this->emitAgentResult(false, ['error' => $e->getMessage()] + $this->failureDetails());
 
             return 1;
         }
 
         if ($exitCode === 0) {
-            if ($logPath !== false) {
-                @unlink($logPath);
-            }
-
+            $this->discardAgentLog();
             $this->emitAgentResult(true);
         } else {
-            $this->emitAgentResult(false, $this->logDetails($logPath ?: null, $logHandle ?: null));
+            $this->emitAgentResult(false, $this->failureDetails());
         }
 
         return $exitCode;
+    }
+
+    /**
+     * Open a temporary log file to capture subprocess output during agent runs.
+     *
+     * Falls back to a spillable in-memory buffer if a tempfile cannot be opened,
+     * so the install can still proceed even when no diagnostics will be surfaced.
+     */
+    protected function openAgentLog(): StreamOutput
+    {
+        $path = tempnam(sys_get_temp_dir(), 'laravel-installer-');
+        $handle = $path !== false ? @fopen($path, 'w+') : false;
+
+        if ($handle === false) {
+            if ($path !== false) {
+                @unlink($path);
+            }
+
+            return new StreamOutput(fopen('php://temp', 'w+'), OutputInterface::VERBOSITY_NORMAL, false);
+        }
+
+        $this->agentLogPath = $path;
+        $this->agentLogHandle = $handle;
+
+        return new StreamOutput($handle, OutputInterface::VERBOSITY_NORMAL, false);
+    }
+
+    /**
+     * Close and remove the agent log file (used on the success path).
+     */
+    protected function discardAgentLog(): void
+    {
+        if (is_resource($this->agentLogHandle)) {
+            @fclose($this->agentLogHandle);
+            $this->agentLogHandle = null;
+        }
+
+        if ($this->agentLogPath !== null) {
+            @unlink($this->agentLogPath);
+            $this->agentLogPath = null;
+        }
+    }
+
+    /**
+     * Build the log + tail fields for the agent failure payload.
+     */
+    protected function failureDetails(): array
+    {
+        if ($this->agentLogPath === null || ! file_exists($this->agentLogPath)) {
+            return [];
+        }
+
+        if (is_resource($this->agentLogHandle)) {
+            @fflush($this->agentLogHandle);
+        }
+
+        return [
+            'log' => $this->agentLogPath,
+            'tail' => $this->readLogTail($this->agentLogPath),
+        ];
     }
 
     /**
@@ -133,27 +198,6 @@ class NewCommand extends Command
     }
 
     /**
-     * Build the log + tail fields for the agent failure payload.
-     *
-     * @param  resource|null  $logHandle
-     */
-    protected function logDetails(?string $logPath, $logHandle = null): array
-    {
-        if ($logPath === null || ! file_exists($logPath)) {
-            return [];
-        }
-
-        if (is_resource($logHandle)) {
-            @fflush($logHandle);
-        }
-
-        return [
-            'log' => $logPath,
-            'tail' => $this->readLogTail($logPath),
-        ];
-    }
-
-    /**
      * Read the last N lines of the agent log, with ANSI escapes stripped.
      */
     protected function readLogTail(string $path, int $lines = 50): string
@@ -164,8 +208,8 @@ class NewCommand extends Command
             return '';
         }
 
-        $content = preg_replace('/\x1b\[[0-9;?]*[a-zA-Z]/', '', $content);
-        $allLines = preg_split("/\r\n|\n|\r/", rtrim($content));
+        $stripped = preg_replace('/\x1b\[[0-9;?]*[a-zA-Z]/', '', $content);
+        $allLines = preg_split("/\r\n|\n|\r/", rtrim($stripped ?? $content));
 
         return implode("\n", array_slice($allLines, -$lines));
     }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -92,16 +92,16 @@ class NewCommand extends Command
         try {
             $exitCode = parent::run($input, $logOutput);
         } catch (Throwable $e) {
-            $this->emitAgentResult(false, ['error' => $e->getMessage()] + $this->failureDetails());
+            $this->emitAgentFailure(['error' => $e->getMessage()] + $this->failureDetails());
 
             return 1;
         }
 
         if ($exitCode === 0) {
             $this->discardAgentLog();
-            $this->emitAgentResult(true);
+            $this->emitAgentSuccess();
         } else {
-            $this->emitAgentResult(false, $this->failureDetails());
+            $this->emitAgentFailure($this->failureDetails());
         }
 
         return $exitCode;
@@ -116,23 +116,35 @@ class NewCommand extends Command
      */
     protected function openAgentLog(): StreamOutput
     {
-        $path = tempnam(sys_get_temp_dir(), 'laravel-installer-');
-        $handle = $path !== false ? @fopen($path, 'w+') : false;
-
-        if ($handle === false) {
-            if ($path !== false) {
-                @unlink($path);
-            }
-
-            $this->agentLogHandle = fopen('php://temp', 'w+');
-
-            return new StreamOutput($this->agentLogHandle, OutputInterface::VERBOSITY_NORMAL, false);
-        }
+        [$path, $handle] = $this->resolveAgentLogPathAndHandle();
 
         $this->agentLogPath = $path;
         $this->agentLogHandle = $handle;
 
         return new StreamOutput($handle, OutputInterface::VERBOSITY_NORMAL, false);
+    }
+
+    /**
+     * Attempt to open a temporary file for logging, falling back to an in-memory stream on failure.
+     *
+     * @return array{string|null, resource}
+     */
+    protected function resolveAgentLogPathAndHandle(): array
+    {
+        $path = tempnam(sys_get_temp_dir(), 'laravel-installer-');
+        $handle = $path !== false ? @fopen($path, 'w+') : false;
+
+        if ($handle !== false) {
+            return [$path, $handle];
+        }
+
+        if ($path !== false) {
+            @unlink($path);
+        }
+
+        $handle = fopen('php://temp', 'w+');
+
+        return [$path, $handle];
     }
 
     /**
@@ -185,6 +197,22 @@ class NewCommand extends Command
     protected function isAgent(): bool
     {
         return $this->agentResult?->isAgent ?? false;
+    }
+
+    /**
+     * Emit a successful agent result with optional extra payload.
+     */
+    protected function emitAgentSuccess(array $extra = []): void
+    {
+        $this->emitAgentResult(true, $extra);
+    }
+
+    /**
+     * Emit a failed agent result with optional extra payload, merged with log details.
+     */
+    protected function emitAgentFailure(array $extra = []): void
+    {
+        $this->emitAgentResult(false, $extra + $this->failureDetails());
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Composer;
 use Illuminate\Support\ProcessUtils;
 use Illuminate\Support\Str;
 use Laravel\Installer\Console\Enums\NodePackageManager;
+use Laravel\Prompts\Prompt;
 use Laravel\Prompts\Support\Logger;
 use Override;
 use RecursiveDirectoryIterator;
@@ -63,6 +64,8 @@ class NewCommand extends Command
         $input->setInteractive(false);
 
         $logOutput = $this->agent->openLog();
+
+        Prompt::setOutput($logOutput);
 
         try {
             $exitCode = parent::run($input, $logOutput);
@@ -127,15 +130,11 @@ class NewCommand extends Command
 
         $this->configurePrompts($input, $output);
 
-        if (! $this->agent->isActive()) {
-            $this->displayHeader($output);
-        }
+        $this->displayHeader($output);
 
         $this->ensureExtensionsAreAvailable($input, $output);
 
-        if (! $this->agent->isActive()) {
-            $this->checkForUpdate($input, $output);
-        }
+        $this->checkForUpdate($input, $output);
 
         if (! $input->getArgument('name')) {
             $input->setArgument('name', text(
@@ -311,6 +310,10 @@ class NewCommand extends Command
      */
     protected function checkForUpdate(InputInterface $input, OutputInterface $output)
     {
+        if ($this->agent->isActive()) {
+            return;
+        }
+
         $package = 'laravel/installer';
         $version = $this->getApplication()->getVersion();
         $versionData = $this->getLatestVersionData($package);
@@ -663,26 +666,24 @@ class NewCommand extends Command
                 $this->commitChanges('Configure Boost post-update script', $directory, $input, $output);
             }
 
-            if (! $this->agent->isActive()) {
-                info("Application ready in <options=bold>[{$name}]</>. You can start your local development using:");
+            info("Application ready in <options=bold>[{$name}]</>. You can start your local development using:");
 
-                $output->writeln($this->finalStep("cd {$name}"));
+            $output->writeln($this->finalStep("cd {$name}"));
 
-                if (! $runPackageManager) {
-                    $output->writeln($this->finalStep($packageManager->installCommand().' && '.$packageManager->buildCommand()));
-                }
-
-                if ($this->isParkedOnHerdOrValet($directory)) {
-                    $url = $this->generateAppUrl($name, $directory);
-                    $output->writeln($this->finalStep('Open: <options=bold;href='.$url.'>'.$url));
-                } else {
-                    $output->writeln($this->finalStep('composer run dev'));
-                }
-
-                $output->writeln('');
-                $output->writeln(' <fg=cyan;options=bold>New to Laravel?</> Check out our <href=https://laravel.com/docs/installation#next-steps;options=underscore>documentation</>. <options=bold>Build something amazing!</>');
-                $output->writeln('');
+            if (! $runPackageManager) {
+                $output->writeln($this->finalStep($packageManager->installCommand().' && '.$packageManager->buildCommand()));
             }
+
+            if ($this->isParkedOnHerdOrValet($directory)) {
+                $url = $this->generateAppUrl($name, $directory);
+                $output->writeln($this->finalStep('Open: <options=bold;href='.$url.'>'.$url));
+            } else {
+                $output->writeln($this->finalStep('composer run dev'));
+            }
+
+            $output->writeln('');
+            $output->writeln(' <fg=cyan;options=bold>New to Laravel?</> Check out our <href=https://laravel.com/docs/installation#next-steps;options=underscore>documentation</>. <options=bold>Build something amazing!</>');
+            $output->writeln('');
         }
 
         return $process->getExitCode();

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -501,7 +501,7 @@ class NewCommand extends Command
 
         $directory = $this->getInstallationDirectory($name);
 
-        $this->agent->rememberInstallation($name, $directory);
+        $this->agent->rememberInstallation($directory);
 
         $this->composer = new Composer(new Filesystem, $directory);
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Installer\Console;
 
+use AgentDetector\AgentDetector;
+use AgentDetector\AgentResult;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Composer;
 use Illuminate\Support\ProcessUtils;
@@ -16,6 +18,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\PhpExecutableFinder;
@@ -44,9 +47,79 @@ class NewCommand extends Command
     protected $composer;
 
     /**
+     * The detected agent, if any.
+     */
+    protected ?AgentResult $agentResult = null;
+
+    /**
+     * The resolved installation name, captured for agent JSON output.
+     */
+    protected ?string $resolvedName = null;
+
+    /**
+     * The resolved installation directory, captured for agent JSON output.
+     */
+    protected ?string $resolvedDirectory = null;
+
+    /**
+     * Detect agents, suppress interactive output, and emit a JSON result.
+     */
+    #[Override]
+    public function run(InputInterface $input, OutputInterface $output): int
+    {
+        $this->agentResult = AgentDetector::detect();
+
+        if (! $this->isAgent()) {
+            return parent::run($input, $output);
+        }
+
+        $input->setInteractive(false);
+
+        try {
+            $exitCode = parent::run($input, new NullOutput);
+        } catch (Throwable $e) {
+            $this->emitAgentResult(false, ['error' => $e->getMessage()]);
+
+            return 1;
+        }
+
+        $this->emitAgentResult($exitCode === 0);
+
+        return $exitCode;
+    }
+
+    /**
+     * Determine whether this command is running under a detected agent.
+     */
+    protected function isAgent(): bool
+    {
+        return $this->agentResult?->isAgent ?? false;
+    }
+
+    /**
+     * Write the minimal JSON result for agent invocations.
+     */
+    protected function emitAgentResult(bool $success, array $extra = []): void
+    {
+        $payload = ['success' => $success];
+
+        if ($this->resolvedName !== null) {
+            $payload['name'] = $this->resolvedName;
+        }
+
+        if ($this->resolvedDirectory !== null) {
+            $payload['directory'] = $this->resolvedDirectory;
+        }
+
+        foreach ($extra as $key => $value) {
+            $payload[$key] = $value;
+        }
+
+        fwrite(STDOUT, json_encode($payload, JSON_UNESCAPED_SLASHES).PHP_EOL);
+    }
+
+    /**
      * Configure the command options.
-     *
-     * @return void
      */
     #[Override]
     protected function configure(): void
@@ -83,8 +156,6 @@ class NewCommand extends Command
 
     /**
      * Interact with the user before validating the input.
-     *
-     * @return void
      */
     #[Override]
     protected function interact(InputInterface $input, OutputInterface $output): void
@@ -93,11 +164,15 @@ class NewCommand extends Command
 
         $this->configurePrompts($input, $output);
 
-        $this->displayHeader($output);
+        if (! $this->isAgent()) {
+            $this->displayHeader($output);
+        }
 
         $this->ensureExtensionsAreAvailable($input, $output);
 
-        $this->checkForUpdate($input, $output);
+        if (! $this->isAgent()) {
+            $this->checkForUpdate($input, $output);
+        }
 
         if (! $input->getArgument('name')) {
             $input->setArgument('name', text(
@@ -460,6 +535,9 @@ class NewCommand extends Command
 
         $directory = $this->getInstallationDirectory($name);
 
+        $this->resolvedName = $name;
+        $this->resolvedDirectory = $directory;
+
         $this->composer = new Composer(new Filesystem, $directory);
 
         $version = $this->getVersion($input);
@@ -623,24 +701,26 @@ class NewCommand extends Command
                 $this->commitChanges('Configure Boost post-update script', $directory, $input, $output);
             }
 
-            info("Application ready in <options=bold>[{$name}]</>. You can start your local development using:");
+            if (! $this->isAgent()) {
+                info("Application ready in <options=bold>[{$name}]</>. You can start your local development using:");
 
-            $output->writeln($this->finalStep("cd {$name}"));
+                $output->writeln($this->finalStep("cd {$name}"));
 
-            if (! $runPackageManager) {
-                $output->writeln($this->finalStep($packageManager->installCommand().' && '.$packageManager->buildCommand()));
+                if (! $runPackageManager) {
+                    $output->writeln($this->finalStep($packageManager->installCommand().' && '.$packageManager->buildCommand()));
+                }
+
+                if ($this->isParkedOnHerdOrValet($directory)) {
+                    $url = $this->generateAppUrl($name, $directory);
+                    $output->writeln($this->finalStep('Open: <options=bold;href='.$url.'>'.$url));
+                } else {
+                    $output->writeln($this->finalStep('composer run dev'));
+                }
+
+                $output->writeln('');
+                $output->writeln(' <fg=cyan;options=bold>New to Laravel?</> Check out our <href=https://laravel.com/docs/installation#next-steps;options=underscore>documentation</>. <options=bold>Build something amazing!</>');
+                $output->writeln('');
             }
-
-            if ($this->isParkedOnHerdOrValet($directory)) {
-                $url = $this->generateAppUrl($name, $directory);
-                $output->writeln($this->finalStep('Open: <options=bold;href='.$url.'>'.$url));
-            } else {
-                $output->writeln($this->finalStep('composer run dev'));
-            }
-
-            $output->writeln('');
-            $output->writeln(' <fg=cyan;options=bold>New to Laravel?</> Check out our <href=https://laravel.com/docs/installation#next-steps;options=underscore>documentation</>. <options=bold>Build something amazing!</>');
-            $output->writeln('');
         }
 
         return $process->getExitCode();
@@ -661,15 +741,11 @@ class NewCommand extends Command
     {
         $curl = curl_init();
 
-        $headers = array_values(array_filter([
-            'User-Agent: Laravel Installer',
-            match (true) {
-                isset($_SERVER['CLAUDECODE']) && $_SERVER['CLAUDECODE'] === '1' => 'X-Agent: Claude Code',
-                isset($_SERVER['OPENCODE']) && $_SERVER['OPENCODE'] === '1' => 'X-Agent: OpenCode',
-                isset($_SERVER['CURSOR_AGENT']) => 'X-Agent: Cursor',
-                default => null,
-            },
-        ]));
+        $headers = ['User-Agent: Laravel Installer'];
+
+        if ($this->isAgent() && $this->agentResult->name !== null) {
+            $headers[] = 'X-Agent: '.$this->agentResult->name;
+        }
 
         curl_setopt_array($curl, [
             CURLOPT_URL => 'https://laravel.com/new-install',
@@ -1349,7 +1425,7 @@ class NewCommand extends Command
             );
         }
 
-        if (function_exists('Laravel\Prompts\task') && function_exists('pcntl_fork') && ! array_is_list($commands) && $this->useConciseOutput($output)) {
+        if ($this->shouldRunAsTask($output, $commands)) {
             return $this->runCommandsAsTask($commands, $workingPath, $env, $taskLabel);
         }
 
@@ -1361,7 +1437,7 @@ class NewCommand extends Command
 
         $process = Process::fromShellCommandline($commandline, $workingPath, $env, null, null);
 
-        if (Process::isTtySupported()) {
+        if (Process::isTtySupported() && ! $this->isAgent()) {
             try {
                 $process->setTty(true);
             } catch (RuntimeException $e) {
@@ -1374,6 +1450,14 @@ class NewCommand extends Command
         });
 
         return $process;
+    }
+
+    protected function shouldRunAsTask(OutputInterface $output, array $commands): bool
+    {
+        return function_exists('Laravel\Prompts\task')
+            && function_exists('pcntl_fork')
+            && ! array_is_list($commands)
+            && ! $this->isAgent() && $this->useConciseOutput($output);
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -72,10 +72,10 @@ class NewCommand extends Command
         } catch (Throwable $e) {
             $this->agent->emitFailure(['error' => $e->getMessage()]);
 
-            return 1;
+            return self::FAILURE;
         }
 
-        if ($exitCode === 0) {
+        if ($exitCode === self::SUCCESS) {
             $this->agent->emitSuccess();
         } else {
             $this->agent->emitFailure();
@@ -707,7 +707,10 @@ class NewCommand extends Command
         $headers = ['User-Agent: Laravel Installer'];
 
         if ($this->agent->isActive() && $this->agent->name() !== null) {
-            $headers[] = 'X-Agent: '.$this->agent->name();
+            $headers[] = 'X-Agent: '.match ($this->agent->name()) {
+                'Claude' => 'Claude Code', // For legacy purposes
+                default => $this->agent->name(),
+            };
         }
 
         curl_setopt_array($curl, [

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -107,6 +107,95 @@ class NewCommandTest extends TestCase
         $this->assertSame('.', $command->getInstallationDirectoryPublic('.'));
     }
 
+    public function test_read_log_tail_strips_ansi_and_returns_last_lines()
+    {
+        $command = new class extends NewCommand
+        {
+            public function readLogTailPublic(string $path, int $lines = 50): string
+            {
+                return $this->readLogTail($path, $lines);
+            }
+        };
+
+        $path = tempnam(sys_get_temp_dir(), 'installer-tail-test-');
+        file_put_contents(
+            $path,
+            "line one\n\e[31mline two\e[0m\nline three\nline four\n"
+        );
+
+        $tail = $command->readLogTailPublic($path, 2);
+
+        @unlink($path);
+
+        $this->assertSame("line three\nline four", $tail);
+    }
+
+    public function test_read_log_tail_returns_empty_string_for_missing_file()
+    {
+        $command = new class extends NewCommand
+        {
+            public function readLogTailPublic(string $path): string
+            {
+                return $this->readLogTail($path);
+            }
+        };
+
+        $this->assertSame('', $command->readLogTailPublic('/nonexistent/path/'.uniqid()));
+    }
+
+    public function test_agent_mode_emits_single_json_line_with_failure_details()
+    {
+        if (PHP_OS_FAMILY === 'Windows') {
+            $this->markTestSkipped('Subprocess test is for Unix/Linux systems only.');
+        }
+
+        $bin = realpath(__DIR__.'/../bin/laravel');
+        $name = 'tests-output/agent-fail-'.bin2hex(random_bytes(4));
+        $dir = __DIR__.'/../'.$name;
+
+        $cmd = sprintf(
+            '%s new %s --no-boost --database=sqlite --using=does-not-exist/totally-bogus-package',
+            escapeshellarg($bin),
+            escapeshellarg($name)
+        );
+
+        $env = ['CLAUDECODE' => '1', 'PATH' => getenv('PATH'), 'HOME' => getenv('HOME')];
+
+        $process = proc_open(
+            $cmd,
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+            __DIR__.'/..',
+            $env
+        );
+
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit = proc_close($process);
+
+        if (file_exists($dir)) {
+            exec('rm -rf '.escapeshellarg($dir));
+        }
+
+        $lines = preg_split('/\r?\n/', trim($stdout));
+        $this->assertCount(1, $lines, "Expected one JSON line on stdout, got:\n{$stdout}\n---stderr---\n{$stderr}");
+
+        $payload = json_decode($lines[0], true);
+        $this->assertIsArray($payload, "Stdout was not valid JSON: {$lines[0]}");
+        $this->assertFalse($payload['success']);
+        $this->assertSame($name, $payload['name']);
+        $this->assertArrayHasKey('log', $payload);
+        $this->assertArrayHasKey('tail', $payload);
+        $this->assertStringContainsString('totally-bogus-package', $payload['tail']);
+        $this->assertNotSame(0, $exit);
+
+        if (isset($payload['log']) && file_exists($payload['log'])) {
+            @unlink($payload['log']);
+        }
+    }
+
     /**
      * @return \Symfony\Component\Console\Application
      */

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Installer\Console\Tests;
 
+use Laravel\Installer\Console\Agent;
 use Laravel\Installer\Console\Concerns\InteractsWithHerdOrValet;
 use Laravel\Installer\Console\NewCommand;
 use PHPUnit\Framework\TestCase;
@@ -109,21 +110,13 @@ class NewCommandTest extends TestCase
 
     public function test_read_log_tail_strips_ansi_and_returns_last_lines()
     {
-        $command = new class extends NewCommand
-        {
-            public function readLogTailPublic(string $path, int $lines = 50): string
-            {
-                return $this->readLogTail($path, $lines);
-            }
-        };
-
         $path = tempnam(sys_get_temp_dir(), 'installer-tail-test-');
         file_put_contents(
             $path,
             "line one\n\e[31mline two\e[0m\nline three\nline four\n"
         );
 
-        $tail = $command->readLogTailPublic($path, 2);
+        $tail = (new Agent)->readLogTail($path, 2);
 
         @unlink($path);
 
@@ -132,15 +125,7 @@ class NewCommandTest extends TestCase
 
     public function test_read_log_tail_returns_empty_string_for_missing_file()
     {
-        $command = new class extends NewCommand
-        {
-            public function readLogTailPublic(string $path): string
-            {
-                return $this->readLogTail($path);
-            }
-        };
-
-        $this->assertSame('', $command->readLogTailPublic('/nonexistent/path/'.uniqid()));
+        $this->assertSame('', (new Agent)->readLogTail('/nonexistent/path/'.uniqid()));
     }
 
     public function test_agent_mode_emits_single_json_line_with_failure_details()

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -196,9 +196,6 @@ class NewCommandTest extends TestCase
         }
     }
 
-    /**
-     * @return \Symfony\Component\Console\Application
-     */
     private function createApplication(): Application
     {
         $app = new Application('Laravel Installer');

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -170,7 +170,7 @@ class NewCommandTest extends TestCase
         $payload = json_decode($lines[0], true);
         $this->assertIsArray($payload, "Stdout was not valid JSON: {$lines[0]}");
         $this->assertFalse($payload['success']);
-        $this->assertSame($name, $payload['name']);
+        $this->assertSame(basename($name), $payload['name']);
         $this->assertArrayHasKey('log', $payload);
         $this->assertArrayHasKey('tail', $payload);
         $this->assertStringContainsString('totally-bogus-package', $payload['tail']);


### PR DESCRIPTION
When `laravel new` is run under an AI agent, it now suppresses interactive prompts and decorative output and prints a single JSON line to stdout describing the result. 

Success (formatted):

```json
{
    "success": true,
    "name": "new-testing",
    "directory": "/Users/joetannenbaum/Herd/scratchpad/new-testing"
}
```

Error (formatted):

```json
{
    "success": false,
    "name": "new-testing",
    "directory": "/Users/joetannenbaum/Herd/scratchpad/new-testing",
    "error": "Got an error!",
    "log": "/private/var/folders/14/zy82jsrn0j5dvsjyckg_rwjw0000gn/T/laravel-installer-ai4tpjq7hbd38TpbVgX",
    "tail": "      - Installing phar-io/version (3.2.1): Extracting archive\n      - Installing phar-io/manifest (2.0.4): Extracting archive\n      - Installing myclabs/deep-copy (1.13.4): Extracting archive\n      - Installing phpunit/phpunit (12.5.23): Extracting archive\n    45 package suggestions were added by new dependencies, use `composer suggest` to see details.\n    Generating optimized autoload files\n    > Illuminate\\Foundation\\ComposerScripts::postAutoloadDump\n    > @php artisan package:discover --ansi\n    \n INFO Discovering packages. \n\n     inertiajs/inertia-laravel     ..     DONE\n     laravel/fortify     ..     DONE\n     laravel/pail     ..     DONE\n laravel/pao     .. DONE\n     laravel/sail     .. DONE\n     laravel/tinker     ..     DONE\n     laravel/wayfinder     ..     DONE\n     nesbot/carbon     ..     DONE\n     nunomaduro/collision     ..     DONE\n     nunomaduro/termwind     ..     DONE\n    \n    78 packages you are using are looking for funding.\nUse the `composer fund` command to find out more!\n    > @php artisan vendor:publish --tag=laravel-assets --ansi --force\n    \n INFO No publishable resources for tag [laravel-assets]. \n\n    No security vulnerability advisories found.\n    > @php artisan key:generate --ansi\n    \n INFO Application key set successfully. \n\n    > @php -r \"file_exists('database/database.sqlite') || touch('database/database.sqlite');\"\n    > @php artisan migrate --graceful --ansi\n    \n INFO Preparing database. \n\n     Creating migration table     .. 1.71ms     DONE\n\n     INFO Running migrations. \n\n     0001_01_01_000000_create_users_table     .. 2.27ms     DONE\n     0001_01_01_000001_create_cache_table     .. 1.14ms     DONE\n     0001_01_01_000002_create_jobs_table     .. 1.70ms     DONE\n     2025_08_14_170933_add_two_factor_columns_to_users_table     .. 0.80ms     DONE\n    \n    > @php -r \"file_exists('.env') || copy('.env.example', '.env');\"\n    \n INFO Application key set successfully."
}
```