### PR TITLE
feat: support installing specific Laravel version via --version option

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -94,6 +94,7 @@ class NewCommand extends Command
             ->setName('new')
             ->setDescription('Create a new Laravel application')
             ->addArgument('name', InputArgument::REQUIRED)
+            ->addOption('version', 'v', InputOption::VALUE_OPTIONAL, 'Install a specific Laravel version instead of the latest (e.g. --v=13.*)')
             ->addOption('dev', null, InputOption::VALUE_NONE, 'Install the latest "development" release')
             ->addOption('git', null, InputOption::VALUE_NONE, 'Initialize a Git repository')
             ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'The branch that should be created for a new repository', $this->defaultBranch())
@@ -1316,6 +1317,10 @@ class NewCommand extends Command
      */
     protected function getVersion(InputInterface $input)
     {
+        if ($input->getOption('v')) {
+            return $input->getOption('v');
+        }
+
         if ($input->getOption('dev')) {
             return 'dev-master';
         }


### PR DESCRIPTION
feat: support installing specific Laravel version via --version option

Adds an optional --version flag to the "new" command, allowing developers
to install a specific Laravel version directly through the installer.

Example:
  laravel new app --version=13.*

Motivation:
Currently, installing a specific Laravel version requires falling back
to "composer create-project", which bypasses the installer's interactive
features such as starter kits and prompts.

This change allows developers to keep the full installer experience
while still selecting a target Laravel version.

Notes:
- Does not change default behavior (latest version is still used)
- Fully backward compatible
- Avoids introducing additional complexity to the install flow