### PR TITLE
Bug Addressed laravel new crash #512

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -38,6 +38,11 @@ class NewCommand extends Command
     const DATABASE_DRIVERS = ['mysql', 'mariadb', 'pgsql', 'sqlite', 'sqlsrv'];
 
     /**
+     * Track if update check has been performed to prevent recursive execution.
+     */
+    private static bool $updateCheckPerformed = false;
+
+    /**
      * The Composer instance.
      *
      * @var Composer
@@ -309,7 +314,14 @@ class NewCommand extends Command
      * @return void
      */
     protected function checkForUpdate(InputInterface $input, OutputInterface $output)
-    {
+    {// Guard against recursive execution after update
+        if (self::$updateCheckPerformed) {
+            return;
+        }
+
+        self::$updateCheckPerformed = true;
+
+        
         if ($this->agent->isActive()) {
             return;
         }
@@ -365,6 +377,17 @@ class NewCommand extends Command
             return;
         }
 
+        // if (confirm(label: 'Would you like to update now?')) {
+        //     $this->runCommands(
+        //         [
+        //             'Installer updated' => 'composer global update laravel/installer --with-all-dependencies',
+        //         ],
+        //         $input,
+        //         $output,
+        //         taskLabel: 'Updating Laravel installer',
+        //     );
+        //     $this->proxyLaravelNew($input, $output);
+        // }
         if (confirm(label: 'Would you like to update now?')) {
             $this->runCommands(
                 [
@@ -374,7 +397,11 @@ class NewCommand extends Command
                 $output,
                 taskLabel: 'Updating Laravel installer',
             );
-            $this->proxyLaravelNew($input, $output);
+
+            $output->writeln('');
+            $output->writeln('  Installer updated. Please re-run the command.');
+
+            return self::SUCCESS; // ✅ stop loop
         }
     }
 


### PR DESCRIPTION
```
## Problem

When running `laravel new`, if an update is available and the user selects "yes" on the update prompt, the installer executes a Composer update but then re-enters the installer flow again. This causes the update prompt to appear repeatedly, resulting in an infinite or looping behavior.

This breaks the expected CLI flow and interrupts project creation.

---

## Root Cause

After triggering a Composer update, the installer does not properly exit the command execution flow and may re-invoke the installer process again, causing recursive execution.

---

## Solution

Ensure the installer exits cleanly after completing the Composer update process and does not re-trigger any installer or `laravel new` commands internally.

This prevents recursive execution and ensures a single, linear update flow.

---

## Benefits to End Users

- Prevents infinite update prompt loops in CLI
- Improves stability and predictability of `laravel new` command
- Ensures smooth project creation experience
- Reduces confusion during installer updates
- Makes the CLI tool more reliable in real-world usage

---

## Impact

This change is internal only and does not affect:
- Public APIs
- Existing command signatures
- User-facing features (except fixing incorrect behavior)

No breaking changes.

---

## Testing Steps

1. Install Laravel Installer (local dev version)
2. Run:
   ```bash
   laravel new test
```
```