### PR TITLE
Fix uncommenting use RefreshDatabase in Pest.php

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -1022,8 +1022,8 @@ class NewCommand extends Command
             $contents = file_get_contents("$directory/tests/Pest.php");
 
             $contents = str_replace(
-                " // ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)",
-                "    ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)",
+                ' // ->use(RefreshDatabase::class)',
+                '    ->use(RefreshDatabase::class)',
                 $contents,
             );
 


### PR DESCRIPTION
Pest changed to aliasing RefreshDatabase namespace, so the uncommenting in the installer would fail, and causes test cases to fail.

https://github.com/pestphp/pest/commit/6c42e7f4ea877a555389c735a7cf14adc2027730

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
