### PR TITLE
Default to initializing a Git repository; add --no-git opt-out

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -95,6 +95,7 @@ class NewCommand extends Command
             ->setDescription('Create a new Laravel application')
             ->addArgument('name', InputArgument::REQUIRED)
             ->addOption('dev', null, InputOption::VALUE_NONE, 'Install the latest "development" release')
+            ->addOption('git', null, InputOption::VALUE_NONE, 'Applied by default, use --no-git to skip initializing a Git repository')
             ->addOption('no-git', null, InputOption::VALUE_NONE, 'Skip initializing a Git repository')
             ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'The branch that should be created for a new repository', $this->defaultBranch())
             ->addOption('github', null, InputOption::VALUE_OPTIONAL, 'Create a new repository on GitHub', false)

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -95,7 +95,7 @@ class NewCommand extends Command
             ->setDescription('Create a new Laravel application')
             ->addArgument('name', InputArgument::REQUIRED)
             ->addOption('dev', null, InputOption::VALUE_NONE, 'Install the latest "development" release')
-            ->addOption('git', null, InputOption::VALUE_NONE, 'Initialize a Git repository')
+            ->addOption('no-git', null, InputOption::VALUE_NONE, 'Skip initializing a Git repository')
             ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'The branch that should be created for a new repository', $this->defaultBranch())
             ->addOption('github', null, InputOption::VALUE_OPTIONAL, 'Create a new repository on GitHub', false)
             ->addOption('organization', null, InputOption::VALUE_REQUIRED, 'The GitHub organization to create the new repository for')
@@ -611,7 +611,7 @@ class NewCommand extends Command
                 }
             }
 
-            if ($input->getOption('git') || $input->getOption('github') !== false) {
+            if (! $input->getOption('no-git') || $input->getOption('github') !== false) {
                 $this->createRepository($directory, $input, $output);
             }
 
@@ -1108,7 +1108,7 @@ class NewCommand extends Command
      */
     protected function commitChanges(string $message, string $directory, InputInterface $input, OutputInterface $output)
     {
-        if (! $input->getOption('git') && $input->getOption('github') === false) {
+        if ($input->getOption('no-git') && $input->getOption('github') === false) {
             return;
         }
 


### PR DESCRIPTION
## Description

This PR inverts the logic of the git initialization option from `--git` to `--no-git`, making it a flag to skip git initialization rather than enable it.

## Changes

- Renamed the `--git` option to `--no-git` with updated description to reflect that it skips git initialization
- Updated the condition in `execute()` method to check for the negation of `no-git` instead of the presence of `git`
- Updated the condition in `commitChanges()` method to check for `no-git` instead of the negation of `git`

## Rationale

This change improves the default behavior by making git repository initialization the default action when creating a new Laravel application. Users now only need to specify `--no-git` if they explicitly want to skip git initialization, rather than requiring `--git` to enable it. This aligns with the principle of least surprise, as most users would expect git to be initialized by default.

Leaves `--git` in place for backwards compatibility.

## Testing

Existing tests should cover this change as the underlying functionality remains the same—only the option flag and its logic have been inverted.

QA test:

 [x] Works without `--no-git`, making a git repo
 [x] Works with `--no-git`, ignoring making a git repo
 [x] Works with `--no-git` & `--github`, making a git repo

## Disclosure

100% AI made PR, but human tested 👍 