### PR TITLE
Interactive starter kit installer hooks

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -576,7 +576,9 @@ class NewCommand extends Command
             $commands,
             $input,
             $output,
-            env: ['LARAVEL_INSTALLER_DEFER_HOOKS' => '1'],
+            // Starter kits need this env variable to defer execution of 
+            // installer hooks until after the create-project command completes
+            env: ['LARAVEL_INSTALLER_DEFER_HOOKS' => '1'], 
             taskLabel: 'Creating Laravel application',
         ))->isSuccessful()) {
             $hooksProcess = $this->runInstallerHooks($directory, $input, $output);

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -1252,20 +1252,21 @@ class NewCommand extends Command
      */
     protected function normalizeInstallerHookCommand(string $command): string
     {
-        if (str_starts_with($command, '@php ')) {
-            return $this->phpBinary().' '.substr($command, 5);
-        }
+        $replace = [
+            'php' => fn () => $this->phpBinary(),
+            'composer' => fn () => $this->findComposer(),
+        ];
 
-        if ($command === '@php') {
-            return $this->phpBinary();
-        }
+        foreach ($replace as $find => $binary) {
+            $marker = "@{$find}";
 
-        if (str_starts_with($command, '@composer ')) {
-            return $this->findComposer().' '.substr($command, 10);
-        }
+            if (str_starts_with($command, "{$marker} ")) {
+                return $binary().' '.substr($command, strlen("{$marker} "));
+            }
 
-        if ($command === '@composer') {
-            return $this->findComposer();
+            if ($command === $marker) {
+                return $binary();
+            }
         }
 
         return $command;

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -576,8 +576,7 @@ class NewCommand extends Command
             $commands,
             $input,
             $output,
-            // Starter kits need this env variable to defer execution of
-            // installer hooks until after the create-project command completes
+            // Starter kits need to defer execution of hooks until after create-project completes...
             env: ['LARAVEL_INSTALLER_DEFER_HOOKS' => '1'],
             taskLabel: 'Creating Laravel application',
         ))->isSuccessful()) {

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -576,6 +576,7 @@ class NewCommand extends Command
             $commands,
             $input,
             $output,
+            env: ['LARAVEL_INSTALLER_DEFER_HOOKS' => '1'],
             taskLabel: 'Creating Laravel application',
         ))->isSuccessful()) {
             $hooksProcess = $this->runInstallerHooks($directory, $input, $output);

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -576,9 +576,9 @@ class NewCommand extends Command
             $commands,
             $input,
             $output,
-            // Starter kits need this env variable to defer execution of 
+            // Starter kits need this env variable to defer execution of
             // installer hooks until after the create-project command completes
-            env: ['LARAVEL_INSTALLER_DEFER_HOOKS' => '1'], 
+            env: ['LARAVEL_INSTALLER_DEFER_HOOKS' => '1'],
             taskLabel: 'Creating Laravel application',
         ))->isSuccessful()) {
             $hooksProcess = $this->runInstallerHooks($directory, $input, $output);

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -578,6 +578,12 @@ class NewCommand extends Command
             $output,
             taskLabel: 'Creating Laravel application',
         ))->isSuccessful()) {
+            $hooksProcess = $this->runInstallerHooks($directory, $input, $output);
+
+            if ($hooksProcess && ! $hooksProcess->isSuccessful()) {
+                return $hooksProcess->getExitCode();
+            }
+
             if ($name !== '.') {
                 $this->pregReplaceInFile(
                     '/^APP_URL=http:\/\/localhost$/m',
@@ -1198,6 +1204,70 @@ class NewCommand extends Command
 
             return $content;
         });
+    }
+
+    /**
+     * Run any Laravel installer hooks defined by the installed application.
+     */
+    protected function runInstallerHooks(string $directory, InputInterface $input, OutputInterface $output): ?Process
+    {
+        $commands = $this->installerHooks($directory, 'post-create-project');
+
+        if ($commands === []) {
+            return null;
+        }
+
+        return $this->runCommands(
+            $commands,
+            $input,
+            $output,
+            workingPath: $directory,
+            taskLabel: 'Running starter kit hooks',
+        );
+    }
+
+    /**
+     * Get the commands for the given Laravel installer hook.
+     */
+    protected function installerHooks(string $directory, string $hook): array
+    {
+        $composerJson = $directory.'/composer.json';
+
+        if (! file_exists($composerJson)) {
+            return [];
+        }
+
+        $composer = json_decode(file_get_contents($composerJson), true) ?: [];
+
+        return collect($composer['extra']['laravel']['installer'][$hook] ?? [])
+            ->filter(fn ($command) => is_string($command) && $command !== '')
+            ->map(fn ($command) => $this->normalizeInstallerHookCommand($command))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Normalize Composer-style script commands for direct execution by the installer.
+     */
+    protected function normalizeInstallerHookCommand(string $command): string
+    {
+        if (str_starts_with($command, '@php ')) {
+            return $this->phpBinary().' '.substr($command, 5);
+        }
+
+        if ($command === '@php') {
+            return $this->phpBinary();
+        }
+
+        if (str_starts_with($command, '@composer ')) {
+            return $this->findComposer().' '.substr($command, 10);
+        }
+
+        if ($command === '@composer') {
+            return $this->findComposer();
+        }
+
+        return $command;
     }
 
     /**

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -7,6 +7,8 @@ use Laravel\Installer\Console\Concerns\InteractsWithHerdOrValet;
 use Laravel\Installer\Console\NewCommand;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class NewCommandTest extends TestCase
@@ -106,6 +108,104 @@ class NewCommandTest extends TestCase
         $this->assertSame(getcwd().'/'.$relativePath, $command->getInstallationDirectoryPublic($relativePath));
 
         $this->assertSame('.', $command->getInstallationDirectoryPublic('.'));
+    }
+
+    public function test_it_can_read_laravel_installer_hooks()
+    {
+        $directory = __DIR__.'/../tests-output/installer-hooks';
+
+        if (! is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+
+        file_put_contents($directory.'/composer.json', json_encode([
+            'extra' => [
+                'laravel' => [
+                    'installer' => [
+                        'post-create-project' => [
+                            '@php artisan install:features --ansi',
+                            '',
+                            ['not-a-command'],
+                            'php artisan custom:setup',
+                        ],
+                    ],
+                ],
+            ],
+        ]));
+
+        $command = new class extends NewCommand
+        {
+            public function installerHooksPublic(string $directory, string $hook): array
+            {
+                return $this->installerHooks($directory, $hook);
+            }
+        };
+
+        $commands = $command->installerHooksPublic($directory, 'post-create-project');
+
+        $this->assertCount(2, $commands);
+        $this->assertStringEndsWith(' artisan install:features --ansi', $commands[0]);
+        $this->assertSame('php artisan custom:setup', $commands[1]);
+    }
+
+    public function test_missing_laravel_installer_hooks_return_an_empty_array()
+    {
+        $directory = __DIR__.'/../tests-output/missing-installer-hooks';
+
+        if (! is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+
+        file_put_contents($directory.'/composer.json', json_encode(['extra' => []]));
+
+        $command = new class extends NewCommand
+        {
+            public function installerHooksPublic(string $directory, string $hook): array
+            {
+                return $this->installerHooks($directory, $hook);
+            }
+        };
+
+        $this->assertSame([], $command->installerHooksPublic($directory, 'post-create-project'));
+    }
+
+    public function test_failing_laravel_installer_hooks_return_a_failed_process()
+    {
+        $directory = __DIR__.'/../tests-output/failing-installer-hooks';
+
+        if (! is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+
+        file_put_contents($directory.'/composer.json', json_encode([
+            'extra' => [
+                'laravel' => [
+                    'installer' => [
+                        'post-create-project' => [
+                            '@php -r "exit(7);"',
+                        ],
+                    ],
+                ],
+            ],
+        ]));
+
+        $command = new class extends NewCommand
+        {
+            public function runInstallerHooksPublic(string $directory)
+            {
+                $this->agent = new Agent;
+
+                $input = new ArrayInput(['command' => 'new'], (new Application)->getDefinition());
+                $input->setInteractive(false);
+
+                return $this->runInstallerHooks($directory, $input, new BufferedOutput);
+            }
+        };
+
+        $process = $command->runInstallerHooksPublic($directory);
+
+        $this->assertFalse($process->isSuccessful());
+        $this->assertNotSame(0, $process->getExitCode());
     }
 
     public function test_read_log_tail_strips_ansi_and_returns_last_lines()


### PR DESCRIPTION
This adds a `post-create-project` hook so starter kits can run their own setup commands after the Laravel app has been created. Unlike composer scripts, these are executed in interactive mode so starter kits can prompt for choices during installation. Starter kits can configure hooks in their `composer.json` under `extra.laravel.installer.post-create-project`. For example:

```json
    "extra": {
        "laravel": {
            "installer": {
                "post-create-project": [
                    "@php artisan install:features --ansi"
                ]
            }
        }
    }
```

The installer normalizes Composer-style `@php` and `@composer` commands and runs them from the new app directory.