### PR TITLE
Adds a no-node option to skip installing and building NPM dependencies entirely

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -114,6 +114,7 @@ class NewCommand extends Command
             ->addOption('pnpm', null, InputOption::VALUE_NONE, 'Install and build NPM dependencies via PNPM')
             ->addOption('bun', null, InputOption::VALUE_NONE, 'Install and build NPM dependencies via Bun')
             ->addOption('yarn', null, InputOption::VALUE_NONE, 'Install and build NPM dependencies via Yarn')
+            ->addOption('no-node', null, InputOption::VALUE_NONE, 'Skip installing and building NPM dependencies')
             ->addOption('boost', null, InputOption::VALUE_NONE, 'Install Laravel Boost to improve AI assisted coding')
             ->addOption('no-boost', null, InputOption::VALUE_NONE, 'Skip Laravel Boost installation')
             ->addOption('using', null, InputOption::VALUE_OPTIONAL, 'Install a custom starter kit from a community maintained package')
@@ -632,38 +633,10 @@ class NewCommand extends Command
                 $output->writeln('');
             }
 
-            [$packageManager, $runPackageManager] = $this->determinePackageManager($directory, $input);
-
-            $this->configureComposerScripts($packageManager);
-
-            if ($input->getOption('pest') && ! $this->useConciseOutput($output)) {
-                $output->writeln('');
-            }
-
-            if (! $runPackageManager && $input->isInteractive()) {
-                $runPackageManager = confirm(
-                    label: 'Would you like to run <options=bold>'.$packageManager->installCommand().'</> and <options=bold>'.$packageManager->buildCommand().'</>?'
-                );
-            }
-
-            foreach (NodePackageManager::allLockFiles() as $lockFile) {
-                if (! in_array($lockFile, $packageManager->lockFiles()) && file_exists($directory.'/'.$lockFile)) {
-                    (new Filesystem)->delete($directory.'/'.$lockFile);
-                }
-            }
-
-            if ($runPackageManager) {
-                $this->runCommands(
-                    [
-                        'Packages installed' => $packageManager->installCommand(),
-                        'Assets built' => $packageManager->buildCommand(),
-                    ],
-                    $input,
-                    $output,
-                    workingPath: $directory,
-                    taskLabel: 'Setting up frontend dependencies with '.$packageManager->value,
-                );
-            }
+            [$packageManager, $runPackageManager] = match (true) {
+                $input->getOption('no-node') => [NodePackageManager::NPM, false],
+                default => $this->installNodeDependencies($directory, $input, $output),
+            };
 
             if ($input->getOption('boost') && ! $input->getOption('no-boost')) {
                 $this->installBoost($directory, $input, $output);
@@ -678,8 +651,8 @@ class NewCommand extends Command
 
             $output->writeln($this->finalStep("cd {$name}"));
 
-            if (! $runPackageManager) {
-                $output->writeln($this->finalStep($packageManager->installCommand().' && '.$packageManager->buildCommand()));
+            if (! $runPackageManager && ! $input->getOption('no-node')) {
+                $output->writeln($this->finalStep($packageManager->installCommand() . ' && ' . $packageManager->buildCommand()));
             }
 
             if ($this->isParkedOnHerdOrValet($directory)) {
@@ -695,6 +668,49 @@ class NewCommand extends Command
         }
 
         return $process->getExitCode();
+    }
+
+    /**
+     * Install Node dependencies and build assets.
+     *
+     * @return array{NodePackageManager, bool} The package manager used and whether it was run
+     */
+    protected function installNodeDependencies(string $directory, InputInterface $input, OutputInterface $output): array
+    {
+        [$packageManager, $runPackageManager] = $this->determinePackageManager($directory, $input);
+
+        $this->configureComposerScripts($packageManager);
+
+        if ($input->getOption('pest') && ! $this->useConciseOutput($output)) {
+            $output->writeln('');
+        }
+
+        if (! $runPackageManager && $input->isInteractive()) {
+            $runPackageManager = confirm(
+                label: 'Would you like to run <options=bold>' . $packageManager->installCommand() . '</> and <options=bold>' . $packageManager->buildCommand() . '</>?'
+            );
+        }
+
+        foreach (NodePackageManager::allLockFiles() as $lockFile) {
+            if (! in_array($lockFile, $packageManager->lockFiles()) && file_exists($directory . '/' . $lockFile)) {
+                (new Filesystem)->delete($directory . '/' . $lockFile);
+            }
+        }
+
+        if ($runPackageManager) {
+            $this->runCommands(
+                [
+                    'Packages installed' => $packageManager->installCommand(),
+                    'Assets built' => $packageManager->buildCommand(),
+                ],
+                $input,
+                $output,
+                workingPath: $directory,
+                taskLabel: 'Setting up frontend dependencies with ' . $packageManager->value,
+            );
+        }
+
+        return [$packageManager, $runPackageManager];
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -671,49 +671,6 @@ class NewCommand extends Command
     }
 
     /**
-     * Install Node dependencies and build assets.
-     *
-     * @return array{NodePackageManager, bool} The package manager used and whether it was run
-     */
-    protected function installNodeDependencies(string $directory, InputInterface $input, OutputInterface $output): array
-    {
-        [$packageManager, $runPackageManager] = $this->determinePackageManager($directory, $input);
-
-        $this->configureComposerScripts($packageManager);
-
-        if ($input->getOption('pest') && ! $this->useConciseOutput($output)) {
-            $output->writeln('');
-        }
-
-        if (! $runPackageManager && $input->isInteractive()) {
-            $runPackageManager = confirm(
-                label: 'Would you like to run <options=bold>'.$packageManager->installCommand().'</> and <options=bold>'.$packageManager->buildCommand().'</>?'
-            );
-        }
-
-        foreach (NodePackageManager::allLockFiles() as $lockFile) {
-            if (! in_array($lockFile, $packageManager->lockFiles()) && file_exists($directory.'/'.$lockFile)) {
-                (new Filesystem)->delete($directory.'/'.$lockFile);
-            }
-        }
-
-        if ($runPackageManager) {
-            $this->runCommands(
-                [
-                    'Packages installed' => $packageManager->installCommand(),
-                    'Assets built' => $packageManager->buildCommand(),
-                ],
-                $input,
-                $output,
-                workingPath: $directory,
-                taskLabel: 'Setting up frontend dependencies with '.$packageManager->value,
-            );
-        }
-
-        return [$packageManager, $runPackageManager];
-    }
-
-    /**
      * Format the final step command with an arrow and styling.
      */
     protected function finalStep(string $command): string
@@ -1070,6 +1027,49 @@ class NewCommand extends Command
         }
 
         $this->commitChanges('Install Pest', $directory, $input, $output);
+    }
+
+    /**
+     * Install Node dependencies and build assets.
+     *
+     * @return array{NodePackageManager, bool} The package manager used and whether it was run
+     */
+    protected function installNodeDependencies(string $directory, InputInterface $input, OutputInterface $output): array
+    {
+        [$packageManager, $runPackageManager] = $this->determinePackageManager($directory, $input);
+
+        $this->configureComposerScripts($packageManager);
+
+        if ($input->getOption('pest') && ! $this->useConciseOutput($output)) {
+            $output->writeln('');
+        }
+
+        if (! $runPackageManager && $input->isInteractive()) {
+            $runPackageManager = confirm(
+                label: 'Would you like to run <options=bold>'.$packageManager->installCommand().'</> and <options=bold>'.$packageManager->buildCommand().'</>?'
+            );
+        }
+
+        foreach (NodePackageManager::allLockFiles() as $lockFile) {
+            if (! in_array($lockFile, $packageManager->lockFiles()) && file_exists($directory.'/'.$lockFile)) {
+                (new Filesystem)->delete($directory.'/'.$lockFile);
+            }
+        }
+
+        if ($runPackageManager) {
+            $this->runCommands(
+                [
+                    'Packages installed' => $packageManager->installCommand(),
+                    'Assets built' => $packageManager->buildCommand(),
+                ],
+                $input,
+                $output,
+                workingPath: $directory,
+                taskLabel: 'Setting up frontend dependencies with '.$packageManager->value,
+            );
+        }
+
+        return [$packageManager, $runPackageManager];
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -652,7 +652,7 @@ class NewCommand extends Command
             $output->writeln($this->finalStep("cd {$name}"));
 
             if (! $runPackageManager && ! $input->getOption('no-node')) {
-                $output->writeln($this->finalStep($packageManager->installCommand() . ' && ' . $packageManager->buildCommand()));
+                $output->writeln($this->finalStep($packageManager->installCommand().' && '.$packageManager->buildCommand()));
             }
 
             if ($this->isParkedOnHerdOrValet($directory)) {
@@ -687,13 +687,13 @@ class NewCommand extends Command
 
         if (! $runPackageManager && $input->isInteractive()) {
             $runPackageManager = confirm(
-                label: 'Would you like to run <options=bold>' . $packageManager->installCommand() . '</> and <options=bold>' . $packageManager->buildCommand() . '</>?'
+                label: 'Would you like to run <options=bold>'.$packageManager->installCommand().'</> and <options=bold>'.$packageManager->buildCommand().'</>?'
             );
         }
 
         foreach (NodePackageManager::allLockFiles() as $lockFile) {
-            if (! in_array($lockFile, $packageManager->lockFiles()) && file_exists($directory . '/' . $lockFile)) {
-                (new Filesystem)->delete($directory . '/' . $lockFile);
+            if (! in_array($lockFile, $packageManager->lockFiles()) && file_exists($directory.'/'.$lockFile)) {
+                (new Filesystem)->delete($directory.'/'.$lockFile);
             }
         }
 
@@ -706,7 +706,7 @@ class NewCommand extends Command
                 $input,
                 $output,
                 workingPath: $directory,
-                taskLabel: 'Setting up frontend dependencies with ' . $packageManager->value,
+                taskLabel: 'Setting up frontend dependencies with '.$packageManager->value,
             );
         }
 


### PR DESCRIPTION
### Changed

- Adds a `--no-node` option to the installer so it skips installing and building Node dependencies entirely (useful for Starter Kits that don't require Node - like the [Hotwire Starter Kit](https://github.com/hotwired-laravel/hotwire-starter-kit)) 