### PR TITLE
Enable Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,12 @@
+name: dependabot-auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    uses: laravel/.github/.github/workflows/dependabot-auto-merge.yml@c265c45c41ccb723befb7a2b807dffff4595bd39


### PR DESCRIPTION
Adds a thin workflow that calls the shared reusable `dependabot-auto-merge` workflow in `laravel/.github` (pinned by commit SHA), which squash-merges this repo's grouped Dependabot `github-actions` PRs automatically. Patch and minor bumps only; majors (and other ecosystems) stay open for review.