### PR TITLE
Add all-features support for starter kit hooks

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -107,6 +107,7 @@ class NewCommand extends Command
             ->addOption('livewire-class-components', null, InputOption::VALUE_NONE, 'Generate stand-alone Livewire class components')
             ->addOption('workos', null, InputOption::VALUE_NONE, 'Use WorkOS for authentication')
             ->addOption('teams', null, InputOption::VALUE_NONE, 'Install team support')
+            ->addOption('all-features', null, InputOption::VALUE_NONE, 'Install all starter kit features')
             ->addOption('no-authentication', null, InputOption::VALUE_NONE, 'Do not generate authentication scaffolding')
             ->addOption('pest', null, InputOption::VALUE_NONE, 'Install the Pest testing framework')
             ->addOption('phpunit', null, InputOption::VALUE_NONE, 'Install the PHPUnit testing framework')
@@ -581,6 +582,8 @@ class NewCommand extends Command
             env: ['LARAVEL_INSTALLER_DEFER_HOOKS' => '1'],
             taskLabel: 'Creating Laravel application',
         ))->isSuccessful()) {
+            $this->configureStarterKitFeatureHooks($directory, $input);
+
             $hooksProcess = $this->runInstallerHooks($directory, $input, $output);
 
             if ($hooksProcess && ! $hooksProcess->isSuccessful()) {
@@ -1222,6 +1225,93 @@ class NewCommand extends Command
 
             return $content;
         });
+    }
+
+    /**
+     * Configure starter kit feature hooks for non-interactive installer runs.
+     */
+    protected function configureStarterKitFeatureHooks(string $directory, InputInterface $input): void
+    {
+        $composerJson = $directory.'/composer.json';
+
+        if (! file_exists($composerJson)) {
+            return;
+        }
+
+        if ($input->isInteractive() && ! $input->getOption('all-features')) {
+            return;
+        }
+
+        $composer = json_decode(file_get_contents($composerJson), true) ?: [];
+
+        if (! $this->hasStarterKitFeatureHooks($composer)) {
+            return;
+        }
+
+        $this->composer->modify(function (array $content) use ($input) {
+            $allFeatures = $input->getOption('all-features');
+
+            if (isset($content['scripts']['post-update-cmd']) && is_array($content['scripts']['post-update-cmd'])) {
+                $content['scripts']['post-update-cmd'] = $this->configureStarterKitFeatureHookCommands(
+                    $content['scripts']['post-update-cmd'],
+                    $allFeatures,
+                );
+            }
+
+            if (isset($content['extra']['laravel']['installer']['post-create-project']) && is_array($content['extra']['laravel']['installer']['post-create-project'])) {
+                $content['extra']['laravel']['installer']['post-create-project'] = $this->configureStarterKitFeatureHookCommands(
+                    $content['extra']['laravel']['installer']['post-create-project'],
+                    $allFeatures,
+                );
+            }
+
+            return $content;
+        });
+    }
+
+    /**
+     * @param  array<int, mixed>  $commands
+     * @return array<int, mixed>
+     */
+    protected function configureStarterKitFeatureHookCommands(array $commands, bool $allFeatures): array
+    {
+        $configured = [];
+
+        foreach ($commands as $command) {
+            if (! $this->isStarterKitFeatureHook($command)) {
+                $configured[] = $command;
+
+                continue;
+            }
+
+            if ($allFeatures) {
+                $configured[] = $this->withAllStarterKitFeatures($command);
+            }
+        }
+
+        return $configured;
+    }
+
+    protected function hasStarterKitFeatureHooks(array $composer): bool
+    {
+        return collect([
+            $composer['scripts']['post-update-cmd'] ?? [],
+            $composer['extra']['laravel']['installer']['post-create-project'] ?? [],
+        ])->flatten()->contains(fn ($command) => $this->isStarterKitFeatureHook($command));
+    }
+
+    protected function isStarterKitFeatureHook(mixed $command): bool
+    {
+        return is_string($command) && str_contains($command, 'artisan install:features');
+    }
+
+    protected function withAllStarterKitFeatures(string $command): string
+    {
+        if (preg_match('/(?:^|\s)--all(?:\s|$)/', $command)) {
+            return $command;
+        }
+
+        return $command.' --all';
     }
 
     /**

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Installer\Console\Tests;
 
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Composer;
 use Laravel\Installer\Console\Agent;
 use Laravel\Installer\Console\Concerns\InteractsWithHerdOrValet;
 use Laravel\Installer\Console\NewCommand;
@@ -14,6 +16,115 @@ use Symfony\Component\Console\Tester\CommandTester;
 class NewCommandTest extends TestCase
 {
     use InteractsWithHerdOrValet;
+
+    public function test_all_features_updates_starter_kit_feature_hooks()
+    {
+        $directory = __DIR__.'/../tests-output/all-features-hooks';
+
+        $this->writeComposerJson($directory, [
+            'scripts' => [
+                'post-update-cmd' => [
+                    '@php artisan install:features --ansi',
+                    '@php artisan vendor:publish --tag=laravel-assets --ansi --force',
+                ],
+            ],
+            'extra' => [
+                'laravel' => [
+                    'installer' => [
+                        'post-create-project' => [
+                            '@php artisan install:features --ansi',
+                            'php artisan custom:setup',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $command = $this->newFeatureHooksCommand();
+
+        $command->configureStarterKitFeatureHooksPublic($directory, ['--all-features' => true]);
+
+        $composer = $this->readComposerJson($directory);
+
+        $this->assertSame([
+            '@php artisan install:features --ansi --all',
+            '@php artisan vendor:publish --tag=laravel-assets --ansi --force',
+        ], $composer['scripts']['post-update-cmd']);
+
+        $this->assertSame([
+            '@php artisan install:features --ansi --all',
+            'php artisan custom:setup',
+        ], $composer['extra']['laravel']['installer']['post-create-project']);
+    }
+
+    public function test_non_interactive_runs_without_all_features_remove_starter_kit_feature_hooks()
+    {
+        $directory = __DIR__.'/../tests-output/non-interactive-feature-hooks';
+
+        $this->writeComposerJson($directory, [
+            'scripts' => [
+                'post-update-cmd' => [
+                    '@php artisan install:features --ansi',
+                    '@php artisan vendor:publish --tag=laravel-assets --ansi --force',
+                ],
+            ],
+            'extra' => [
+                'laravel' => [
+                    'installer' => [
+                        'post-create-project' => [
+                            '@php artisan install:features --ansi',
+                            'php artisan custom:setup',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $command = $this->newFeatureHooksCommand();
+
+        $command->configureStarterKitFeatureHooksPublic($directory);
+
+        $composer = $this->readComposerJson($directory);
+
+        $this->assertSame([
+            '@php artisan vendor:publish --tag=laravel-assets --ansi --force',
+        ], $composer['scripts']['post-update-cmd']);
+
+        $this->assertSame([
+            'php artisan custom:setup',
+        ], $composer['extra']['laravel']['installer']['post-create-project']);
+    }
+
+    public function test_interactive_runs_without_all_features_keep_starter_kit_feature_hooks()
+    {
+        $directory = __DIR__.'/../tests-output/interactive-feature-hooks';
+
+        $this->writeComposerJson($directory, [
+            'scripts' => [
+                'post-update-cmd' => [
+                    '@php artisan install:features --ansi',
+                ],
+            ],
+            'extra' => [
+                'laravel' => [
+                    'installer' => [
+                        'post-create-project' => [
+                            '@php artisan install:features --ansi',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $command = $this->newFeatureHooksCommand();
+
+        $command->configureStarterKitFeatureHooksPublic($directory, interactive: true);
+
+        $composer = $this->readComposerJson($directory);
+
+        $this->assertSame(['@php artisan install:features --ansi'], $composer['scripts']['post-update-cmd']);
+        $this->assertSame(['@php artisan install:features --ansi'], $composer['extra']['laravel']['installer']['post-create-project']);
+    }
 
     public function test_it_can_scaffold_a_new_laravel_app()
     {
@@ -292,5 +403,40 @@ class NewCommandTest extends TestCase
         }
 
         return $app;
+    }
+
+    private function newFeatureHooksCommand(): NewCommand
+    {
+        return new class extends NewCommand
+        {
+            public function configureStarterKitFeatureHooksPublic(string $directory, array $options = [], bool $interactive = false): void
+            {
+                $this->composer = new Composer(new Filesystem, $directory);
+
+                $input = new ArrayInput(['name' => 'example-app', ...$options], $this->getDefinition());
+                $input->setInteractive($interactive);
+
+                $this->configureStarterKitFeatureHooks($directory, $input);
+            }
+
+            public function installerHooksPublic(string $directory, string $hook): array
+            {
+                return $this->installerHooks($directory, $hook);
+            }
+        };
+    }
+
+    private function writeComposerJson(string $directory, array $composer): void
+    {
+        if (! is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+
+        file_put_contents($directory.'/composer.json', json_encode($composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+
+    private function readComposerJson(string $directory): array
+    {
+        return json_decode(file_get_contents($directory.'/composer.json'), true, 512, JSON_THROW_ON_ERROR);
     }
 }


### PR DESCRIPTION
Non-interactive installs can block when a starter kit runs the feature installer hook and waits for prompts. This adds an \`--all-features\` option so the installer can opt into every starter kit feature without requiring interactive input.

When \`--all-features\` is present, starter kit feature hooks are updated to pass \`--all\` through to Maestro. In non-interactive runs without that option, the feature hook is removed so the installation can finish without hanging.

Related Maestro PR: https://github.com/laravel/maestro/pull/165