### PR TITLE
Respect --no-interaction flag when attaching TTY to child processes

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -1492,7 +1492,7 @@ class NewCommand extends Command
 
         $process = Process::fromShellCommandline($commandline, $workingPath, $env, null, null);
 
-        if (Process::isTtySupported() && ! $this->agent->isActive()) {
+        if (Process::isTtySupported() && $input->isInteractive() && ! $this->agent->isActive()) {
             try {
                 $process->setTty(true);
             } catch (RuntimeException $e) {


### PR DESCRIPTION
When running `laravel new` with `--no-interaction`, the TTY was still attached to child processes because the check only looked at agent detection. This meant Composer scripts (like starter kit `post-update-cmd` hooks) would still run interactively. Now the TTY is only attached when `$input->isInteractive()` is true.