### PR TITLE
Use `php artisan dev` in get started steps

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -769,7 +769,7 @@ class NewCommand extends Command
                 $url = $this->generateAppUrl($name, $directory);
                 $getStartedSteps[] = 'Open: '.Element::link($url);
             } else {
-                $getStartedSteps[] = 'composer run dev';
+                $getStartedSteps[] = 'php artisan dev';
             }
 
             if (function_exists('Laravel\Prompts\callout')) {


### PR DESCRIPTION
Replaces `composer run dev` with `php artisan dev` in the "You can start your local development using:" steps shown after `laravel new`, so the installer points to the newer first-party command.

```
You can start your local development using:

1. cd my-app
2. php artisan dev
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)